### PR TITLE
Only set current action if entity still exists after calling `add`

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -362,4 +362,24 @@ mod tests {
         assert!(world.get::<CurrentAction>(e).unwrap().0.is_some());
         assert!(world.get::<ActionQueue>(e).unwrap().0.len() == 0);
     }
+
+    #[test]
+    fn despawn() {
+        struct DespawnAction;
+        impl Action for DespawnAction {
+            fn add(&mut self, actor: Entity, world: &mut World, _commands: &mut ActionCommands) {
+                world.despawn(actor);
+            }
+            fn remove(&mut self, _actor: Entity, _world: &mut World) {}
+            fn stop(&mut self, _actor: Entity, _world: &mut World) {}
+        }
+
+        let mut world = World::new();
+
+        let e = world.spawn().insert_bundle(ActionsBundle::default()).id();
+
+        world.add_action(e, DespawnAction, AddConfig::default());
+
+        assert!(world.get_entity(e).is_none());
+    }
 }

--- a/src/world.rs
+++ b/src/world.rs
@@ -113,8 +113,9 @@ impl ActionsWorldExt for World {
         let mut commands = ActionCommands::default();
         if let Some((mut action, cfg)) = next {
             action.add(actor, self, &mut commands);
-            let mut current = self.get_mut::<CurrentAction>(actor).unwrap();
-            current.0 = Some((action, cfg));
+            if let Some(mut current) = self.get_mut::<CurrentAction>(actor) {
+                current.0 = Some((action, cfg));
+            }
         }
 
         commands.apply(self);


### PR DESCRIPTION
One may wish to despawn an entity as its _last_ action:

```rust
struct DespawnAction;

impl Action for DespawnAction {
    fn add(&mut self, actor: Entity, world: &mut World, _commands: &mut ActionCommands) {
        world.despawn(actor);
    }

    fn remove(&mut self, _actor: Entity, _world: &mut World) {}
    fn stop(&mut self, _actor: Entity, _world: &mut World) {}
}
```

This is now possible by setting the current action more gracefully after `add` has been called.