### PR TITLE
Simplify API

### DIFF
--- a/README.md
+++ b/README.md
@@ -45,7 +45,7 @@ fn setup(mut commands: Commands) {
 struct WaitAction(f32);
 
 impl Action for WaitAction {
-    fn add(&mut self, entity: Entity, world: &mut World, _commands: &mut ActionCommands) {
+    fn start(&mut self, entity: Entity, world: &mut World, _commands: &mut ActionCommands) {
         world.entity_mut(entity).insert(Wait(self.0));
     }
 

--- a/README.md
+++ b/README.md
@@ -2,9 +2,7 @@
 
 `bevy_sequential_actions` is a library for the [Bevy game engine](https://bevyengine.org/ "bevy game engine") that aims to execute a list of actions in a sequential manner. This generally means that one action runs at a time, and when it is done, the next action will start, and so on until the list is empty.
 
-<p align="center">
-  <img src="https://user-images.githubusercontent.com/19198785/165852063-ad6b61ad-da12-4a95-9861-5bb8693fd7ff.gif">
-</p>
+https://user-images.githubusercontent.com/19198785/167969191-48258eb3-8acb-4f38-a326-f34e055a1b40.mp4
 
 ## Getting Started
 

--- a/README.md
+++ b/README.md
@@ -8,11 +8,10 @@
 
 ## Getting Started
 
-An action is anything that implements the `Action` trait, and can be added to any `Entity` that contains the `ActionsBundle`. Each action must signal when they are finished, which is done by calling `next_action` on either `Commands` or `ActionCommands`.
+An action is anything that implements the `Action` trait, and can be added to any `Entity` that contains the `ActionsBundle`. Each action must signal when they are finished, which is done by calling the `next` method from either `Commands` or `ActionCommands`.
 
 ```rust
 use bevy::prelude::*;
-
 use bevy_sequential_actions::*;
 
 fn main() {
@@ -25,42 +24,39 @@ fn main() {
 
 fn setup(mut commands: Commands) {
     // Create entity with ActionsBundle
-    let id = commands.spawn_bundle(ActionsBundle::default()).id();
+    let entity = commands.spawn_bundle(ActionsBundle::default()).id();
 
     // Add a single action with default config
-    commands.add_action(id, WaitAction(1.0), AddConfig::default());
+    commands.action(entity).add(WaitAction(1.0));
 
     // Add multiple actions with custom config
     commands
-        .action_builder(
-            id,
-            AddConfig {
-                // Add each action to the back of the queue
-                order: AddOrder::Back,
-                // Start action if nothing is currently running
-                start: false,
-                // Repeat the action         
-                repeat: false,
-            },
-        )
-        .push(WaitAction(2.0))
-        .push(WaitAction(3.0))
-        .submit();
+        .action(entity)
+        .config(AddConfig {
+            // Add each action to the back of the queue
+            order: AddOrder::Back,
+            // Start action if nothing is currently running
+            start: false,
+            // Repeat the action
+            repeat: false,
+        })
+        .add(WaitAction(2.0))
+        .add(WaitAction(3.0));
 }
 
 struct WaitAction(f32);
 
 impl Action for WaitAction {
-    fn add(&mut self, actor: Entity, world: &mut World, _commands: &mut ActionCommands) {
-        world.entity_mut(actor).insert(Wait(self.0));
+    fn add(&mut self, entity: Entity, world: &mut World, _commands: &mut ActionCommands) {
+        world.entity_mut(entity).insert(Wait(self.0));
     }
 
-    fn remove(&mut self, actor: Entity, world: &mut World) {
-        world.entity_mut(actor).remove::<Wait>();
+    fn remove(&mut self, entity: Entity, world: &mut World) {
+        world.entity_mut(entity).remove::<Wait>();
     }
 
-    fn stop(&mut self, actor: Entity, world: &mut World) {
-        self.remove(actor, world);
+    fn stop(&mut self, entity: Entity, world: &mut World) {
+        self.remove(entity, world);
     }
 }
 
@@ -68,11 +64,11 @@ impl Action for WaitAction {
 struct Wait(f32);
 
 fn wait(mut wait_q: Query<(Entity, &mut Wait)>, time: Res<Time>, mut commands: Commands) {
-    for (actor, mut wait) in wait_q.iter_mut() {
+    for (entity, mut wait) in wait_q.iter_mut() {
         wait.0 -= time.delta_seconds();
         if wait.0 <= 0.0 {
             // Action is finished, issue next.
-            commands.next_action(actor);
+            commands.action(entity).next();
         }
     }
 }

--- a/examples/basic.rs
+++ b/examples/basic.rs
@@ -25,22 +25,21 @@ fn setup(mut commands: Commands) {
             start: false,          // Start action if nothing is currently running
             repeat: false,         // Repeat the action
         })
-        .push(WaitAction(4.0))
-        .push(WaitAction(5.0))
-        .submit();
+        .add(WaitAction(4.0))
+        .add(WaitAction(5.0));
 
-    // Add multiple actions again but to the front of the queue
+    // Push multiple actions to the front and reverse order before submitting
     commands
         .action(entity)
         .config(AddConfig {
-            order: AddOrder::Front, // This time, add each action to the front of the queue
+            order: AddOrder::Front, // This time, add each action to the front
             start: false,
             repeat: false,
         })
         .push(WaitAction(2.0))
         .push(WaitAction(3.0))
-        .reverse() // Since we are adding to the front, reverse the order to get increasing wait times
-        .submit();
+        .reverse() // Reverse the order to get increasing wait times
+        .submit(); // When pushing, actions are not queued until submit is called.
 
     // Add an action that itself adds multiple actions
     commands.action(entity).add(MultipleWaitActions);

--- a/examples/basic.rs
+++ b/examples/basic.rs
@@ -15,42 +15,38 @@ fn setup(mut commands: Commands) {
     let id = commands.spawn_bundle(ActionsBundle::default()).id();
 
     // Add a single action with default config
-    commands.add_action(id, WaitAction(1.0), AddConfig::default());
+    commands.action(id).add(WaitAction(1.0));
 
     // Add multiple actions with custom config
     commands
-        .action_builder(
-            id,
-            AddConfig {
-                order: AddOrder::Back, // Add each action to the back of the queue
-                start: false,          // Start action if nothing is currently running
-                repeat: false,         // Repeat the action
-            },
-        )
+        .action(id)
+        .config(AddConfig {
+            order: AddOrder::Back, // Add each action to the back of the queue
+            start: false,          // Start action if nothing is currently running
+            repeat: false,         // Repeat the action
+        })
         .push(WaitAction(4.0))
         .push(WaitAction(5.0))
         .submit();
 
     // Add multiple actions again but to the front of the queue
     commands
-        .action_builder(
-            id,
-            AddConfig {
-                order: AddOrder::Front, // This time, add each action to the front of the queue
-                start: false,
-                repeat: false,
-            },
-        )
+        .action(id)
+        .config(AddConfig {
+            order: AddOrder::Front, // This time, add each action to the front of the queue
+            start: false,
+            repeat: false,
+        })
         .push(WaitAction(2.0))
         .push(WaitAction(3.0))
         .reverse() // Since we are adding to the front, reverse the order to get increasing wait times
         .submit();
 
     // Add an action that itself adds multiple actions
-    commands.add_action(id, MultipleWaitActions, AddConfig::default());
+    commands.action(id).add(MultipleWaitActions);
 
     // Finally, quit the app
-    commands.add_action(id, QuitAction, AddConfig::default());
+    commands.action(id).add(QuitAction);
 
     // A list of actions have now been added to the queue, and should execute in the following order:
     // Wait(1.0)
@@ -90,7 +86,7 @@ fn wait(mut wait_q: Query<(Entity, &mut Wait)>, time: Res<Time>, mut commands: C
         wait.0 -= time.delta_seconds();
         if wait.0 <= 0.0 {
             // To signal that an action has finished, the next action method must be called.
-            commands.next_action(actor);
+            commands.action(actor).next();
         }
     }
 }

--- a/examples/basic.rs
+++ b/examples/basic.rs
@@ -97,23 +97,19 @@ impl Action for MultipleWaitActions {
     fn add(&mut self, actor: Entity, _world: &mut World, commands: &mut ActionCommands) {
         // This action simply creates new actions to the front of the queue.
         commands
-            .action_builder(
-                actor,
-                AddConfig {
-                    order: AddOrder::Front,
-                    start: false,
-                    repeat: false,
-                },
-            )
+            .action(actor)
+            .config(AddConfig {
+                order: AddOrder::Front,
+                start: false,
+                repeat: false,
+            })
             .push(WaitAction(4.0))
             .push(WaitAction(3.0))
             .push(WaitAction(2.0))
             .push(WaitAction(1.0))
             .reverse()
-            .submit();
-
-        // Since this is all that it does, we call next action as it is finished.
-        commands.next_action(actor);
+            .submit()
+            .next(); // Since this is all that it does, we call next action as it is finished.
     }
 
     fn remove(&mut self, _actor: Entity, _world: &mut World) {}

--- a/examples/basic.rs
+++ b/examples/basic.rs
@@ -63,7 +63,7 @@ fn setup(mut commands: Commands) {
 struct WaitAction(f32);
 
 impl Action for WaitAction {
-    fn add(&mut self, entity: Entity, world: &mut World, _commands: &mut ActionCommands) {
+    fn start(&mut self, entity: Entity, world: &mut World, _commands: &mut ActionCommands) {
         println!("Wait({})", self.0);
         world.entity_mut(entity).insert(Wait(self.0));
     }
@@ -93,7 +93,7 @@ fn wait(mut wait_q: Query<(Entity, &mut Wait)>, time: Res<Time>, mut commands: C
 struct MultipleWaitActions;
 
 impl Action for MultipleWaitActions {
-    fn add(&mut self, entity: Entity, _world: &mut World, commands: &mut ActionCommands) {
+    fn start(&mut self, entity: Entity, _world: &mut World, commands: &mut ActionCommands) {
         // This action simply creates new actions to the front of the queue.
         commands
             .action(entity)
@@ -118,7 +118,7 @@ impl Action for MultipleWaitActions {
 struct QuitAction;
 
 impl Action for QuitAction {
-    fn add(&mut self, _entity: Entity, world: &mut World, _commands: &mut ActionCommands) {
+    fn start(&mut self, _entity: Entity, world: &mut World, _commands: &mut ActionCommands) {
         println!("Quit");
         let mut app_exit_ev = world.resource_mut::<Events<AppExit>>();
         app_exit_ev.send(AppExit);

--- a/examples/demo/bevy_actions/camera_action.rs
+++ b/examples/demo/bevy_actions/camera_action.rs
@@ -29,7 +29,7 @@ impl Action for CameraAction {
         match *self {
             CameraAction::Follow(target) => {
                 world.camera(CameraCommand::Follow(target));
-                commands.next_action(actor);
+                commands.action(actor).next();
             }
             CameraAction::Pan(target, duration) => {
                 world.camera(CameraCommand::Stop);
@@ -53,16 +53,15 @@ impl Action for CameraAction {
 
                 let lerp = LerpAction::new(camera, LerpType::Position(target_pos), duration);
 
-                commands.add_action(
-                    actor,
-                    lerp,
-                    AddConfig {
+                commands
+                    .action(actor)
+                    .config(AddConfig {
                         order: AddOrder::Front,
                         start: false,
                         repeat: false,
-                    },
-                );
-                commands.next_action(actor);
+                    })
+                    .add(lerp)
+                    .next();
             }
         }
     }

--- a/examples/demo/bevy_actions/camera_action.rs
+++ b/examples/demo/bevy_actions/camera_action.rs
@@ -25,7 +25,7 @@ pub enum PanTarget {
 }
 
 impl Action for CameraAction {
-    fn add(&mut self, actor: Entity, world: &mut World, commands: &mut ActionCommands) {
+    fn start(&mut self, actor: Entity, world: &mut World, commands: &mut ActionCommands) {
         match *self {
             CameraAction::Follow(target) => {
                 world.camera(CameraCommand::Follow(target));

--- a/examples/demo/bevy_actions/lerp_action.rs
+++ b/examples/demo/bevy_actions/lerp_action.rs
@@ -59,7 +59,7 @@ impl Action for LerpAction {
                 let dir = b.translation - a.translation;
 
                 if dir == Vec3::ZERO {
-                    commands.next_action(actor);
+                    commands.action(actor).next();
                     return;
                 }
 

--- a/examples/demo/bevy_actions/lerp_action.rs
+++ b/examples/demo/bevy_actions/lerp_action.rs
@@ -38,7 +38,7 @@ pub enum LerpType {
 }
 
 impl Action for LerpAction {
-    fn add(&mut self, actor: Entity, world: &mut World, commands: &mut ActionCommands) {
+    fn start(&mut self, actor: Entity, world: &mut World, commands: &mut ActionCommands) {
         let lerp = match self.lerp_type {
             LerpType::Position(target) => {
                 let start = world.get::<Transform>(self.target).unwrap().translation;

--- a/examples/demo/bevy_actions/lerp_action.rs
+++ b/examples/demo/bevy_actions/lerp_action.rs
@@ -137,10 +137,10 @@ fn lerp(
             }
 
             if timer.0.finished() {
-                commands.next_action(actor.0);
+                commands.action(actor.0).next();
             }
         } else {
-            commands.next_action(actor.0);
+            commands.action(actor.0).next();
         }
     }
 }

--- a/examples/demo/bevy_actions/move_action.rs
+++ b/examples/demo/bevy_actions/move_action.rs
@@ -22,7 +22,7 @@ impl MoveAction {
 }
 
 impl Action for MoveAction {
-    fn add(&mut self, actor: Entity, world: &mut World, _commands: &mut ActionCommands) {
+    fn start(&mut self, actor: Entity, world: &mut World, _commands: &mut ActionCommands) {
         let board = world.get_resource::<Board>().unwrap();
         let start = board.get_cell(world.get::<Transform>(actor).unwrap().translation);
         let goal = self.0;

--- a/examples/demo/bevy_actions/move_action.rs
+++ b/examples/demo/bevy_actions/move_action.rs
@@ -74,7 +74,7 @@ fn move_action(
     for (actor, mut transform, mut index, path, speed) in q.iter_mut() {
         if transform.move_towards(path.0[index.0], speed.0 * time.delta_seconds()) {
             if index.0 == path.0.len() - 1 {
-                commands.next_action(actor);
+                commands.action(actor).next();
                 continue;
             }
 
@@ -84,17 +84,15 @@ fn move_action(
                 let tile = board.get_tile(cell);
 
                 if Tile::Trap == *tile {
-                    commands.stop_action(actor);
-                    commands.add_action(
-                        actor,
-                        TileTrapAction,
-                        AddConfig {
+                    commands
+                        .action(actor)
+                        .stop()
+                        .config(AddConfig {
                             order: AddOrder::Front,
-                            start: false,
+                            start: true,
                             repeat: false,
-                        },
-                    );
-                    commands.next_action(actor);
+                        })
+                        .add(TileTrapAction);
                     continue;
                 }
             }

--- a/examples/demo/bevy_actions/set_state_action.rs
+++ b/examples/demo/bevy_actions/set_state_action.rs
@@ -19,7 +19,7 @@ impl<T: BevyState> SetStateAction<T> {
 }
 
 impl<T: BevyState> Action for SetStateAction<T> {
-    fn add(&mut self, actor: Entity, world: &mut World, commands: &mut ActionCommands) {
+    fn start(&mut self, actor: Entity, world: &mut World, commands: &mut ActionCommands) {
         world.set_state(self.0);
         commands.action(actor).next();
     }

--- a/examples/demo/bevy_actions/set_state_action.rs
+++ b/examples/demo/bevy_actions/set_state_action.rs
@@ -20,12 +20,10 @@ impl<T: BevyState> SetStateAction<T> {
 
 impl<T: BevyState> Action for SetStateAction<T> {
     fn add(&mut self, actor: Entity, world: &mut World, commands: &mut ActionCommands) {
-        let mut state = world.get_resource_mut::<State<T>>().unwrap();
-        state.set(self.0).unwrap();
-        commands.next_action(actor);
+        world.set_state(self.0);
+        commands.action(actor).next();
     }
 
     fn remove(&mut self, _actor: Entity, _world: &mut World) {}
-
     fn stop(&mut self, _actor: Entity, _world: &mut World) {}
 }

--- a/examples/demo/bevy_actions/tile_event_action.rs
+++ b/examples/demo/bevy_actions/tile_event_action.rs
@@ -28,14 +28,12 @@ impl Action for TileEventAction {
                 .unwrap();
 
             commands
-                .action_builder(
-                    actor,
-                    AddConfig {
-                        order: AddOrder::Front,
-                        start: false,
-                        repeat: false,
-                    },
-                )
+                .action(actor)
+                .config(AddConfig {
+                    order: AddOrder::Front,
+                    start: false,
+                    repeat: false,
+                })
                 .push(CameraAction::Pan(PanTarget::Entity(actor), 0.5))
                 .push(LerpAction::new(
                     camera,
@@ -53,10 +51,9 @@ impl Action for TileEventAction {
                 .submit();
         }
 
-        commands.next_action(actor);
+        commands.action(actor).next();
     }
 
     fn remove(&mut self, _actor: Entity, _world: &mut World) {}
-
     fn stop(&mut self, _actor: Entity, _world: &mut World) {}
 }

--- a/examples/demo/bevy_actions/tile_event_action.rs
+++ b/examples/demo/bevy_actions/tile_event_action.rs
@@ -14,7 +14,7 @@ impl Plugin for TileEventActionPlugin {
 pub struct TileEventAction;
 
 impl Action for TileEventAction {
-    fn add(&mut self, actor: Entity, world: &mut World, commands: &mut ActionCommands) {
+    fn start(&mut self, actor: Entity, world: &mut World, commands: &mut ActionCommands) {
         let pos = world.get::<Transform>(actor).unwrap().translation;
         let board = world.resource::<Board>();
         let cell = board.get_cell(pos);

--- a/examples/demo/bevy_actions/tile_trap_action.rs
+++ b/examples/demo/bevy_actions/tile_trap_action.rs
@@ -49,6 +49,6 @@ fn on_stop_update(
     mut commands: Commands,
 ) {
     if keyboard.just_pressed(KeyCode::Return) {
-        commands.next_action(actor_q.single());
+        commands.action(actor_q.single()).next();
     }
 }

--- a/examples/demo/bevy_actions/tile_trap_action.rs
+++ b/examples/demo/bevy_actions/tile_trap_action.rs
@@ -14,7 +14,7 @@ impl Plugin for TileTrapActionPlugin {
 pub struct TileTrapAction;
 
 impl Action for TileTrapAction {
-    fn add(&mut self, actor: Entity, world: &mut World, _commands: &mut ActionCommands) {
+    fn start(&mut self, actor: Entity, world: &mut World, _commands: &mut ActionCommands) {
         println!("\n---------- Tile Trap Event! ----------");
         println!("Press 'Enter' to continue.\n");
 

--- a/examples/demo/bevy_actions/wait_action.rs
+++ b/examples/demo/bevy_actions/wait_action.rs
@@ -19,7 +19,7 @@ impl WaitAction {
 }
 
 impl Action for WaitAction {
-    fn add(&mut self, actor: Entity, world: &mut World, _commands: &mut ActionCommands) {
+    fn start(&mut self, actor: Entity, world: &mut World, _commands: &mut ActionCommands) {
         world.entity_mut(actor).insert(Wait(self.0));
     }
 

--- a/examples/demo/bevy_actions/wait_action.rs
+++ b/examples/demo/bevy_actions/wait_action.rs
@@ -39,7 +39,7 @@ fn wait(mut wait_q: Query<(Entity, &mut Wait)>, time: Res<Time>, mut commands: C
     for (actor, mut wait) in wait_q.iter_mut() {
         wait.0 -= time.delta_seconds();
         if wait.0 <= 0.0 {
-            commands.next_action(actor);
+            commands.action(actor).next();
         }
     }
 }

--- a/examples/demo/main.rs
+++ b/examples/demo/main.rs
@@ -149,7 +149,7 @@ fn on_input(
                 let focus = focus_q.single();
                 let cell = board.get_cell(focus.1.translation);
                 commands
-                    .action_builder(player, AddConfig::default())
+                    .action(player)
                     .push(SetStateAction::new(GameState::None))
                     .push(CameraAction::Pan(PanTarget::Entity(player), 1.0))
                     .push(CameraAction::Follow(player))

--- a/examples/repeat.rs
+++ b/examples/repeat.rs
@@ -12,11 +12,11 @@ fn main() {
 
 fn setup(mut commands: Commands) {
     // Create entity with ActionsBundle
-    let id = commands.spawn_bundle(ActionsBundle::default()).id();
+    let entity = commands.spawn_bundle(ActionsBundle::default()).id();
 
     // Add three wait actions with custom config
     commands
-        .action(id)
+        .action(entity)
         .config(AddConfig {
             order: AddOrder::Back, // Add each action to the back of the queue
             start: true,           // Start action if nothing is currently running
@@ -33,17 +33,17 @@ fn setup(mut commands: Commands) {
 struct WaitAction(f32);
 
 impl Action for WaitAction {
-    fn add(&mut self, actor: Entity, world: &mut World, _commands: &mut ActionCommands) {
+    fn add(&mut self, entity: Entity, world: &mut World, _commands: &mut ActionCommands) {
         println!("Wait({})", self.0);
-        world.entity_mut(actor).insert(Wait(self.0));
+        world.entity_mut(entity).insert(Wait(self.0));
     }
 
-    fn remove(&mut self, actor: Entity, world: &mut World) {
-        world.entity_mut(actor).remove::<Wait>();
+    fn remove(&mut self, entity: Entity, world: &mut World) {
+        world.entity_mut(entity).remove::<Wait>();
     }
 
-    fn stop(&mut self, actor: Entity, world: &mut World) {
-        self.remove(actor, world);
+    fn stop(&mut self, entity: Entity, world: &mut World) {
+        self.remove(entity, world);
     }
 }
 
@@ -51,11 +51,11 @@ impl Action for WaitAction {
 struct Wait(f32);
 
 fn wait(mut wait_q: Query<(Entity, &mut Wait)>, time: Res<Time>, mut commands: Commands) {
-    for (actor, mut wait) in wait_q.iter_mut() {
+    for (entity, mut wait) in wait_q.iter_mut() {
         wait.0 -= time.delta_seconds();
         if wait.0 <= 0.0 {
             // To signal that an action has finished, the next action method must be called.
-            commands.action(actor).next();
+            commands.action(entity).next();
         }
     }
 }

--- a/examples/repeat.rs
+++ b/examples/repeat.rs
@@ -33,7 +33,7 @@ fn setup(mut commands: Commands) {
 struct WaitAction(f32);
 
 impl Action for WaitAction {
-    fn add(&mut self, entity: Entity, world: &mut World, _commands: &mut ActionCommands) {
+    fn start(&mut self, entity: Entity, world: &mut World, _commands: &mut ActionCommands) {
         println!("Wait({})", self.0);
         world.entity_mut(entity).insert(Wait(self.0));
     }

--- a/examples/repeat.rs
+++ b/examples/repeat.rs
@@ -16,14 +16,12 @@ fn setup(mut commands: Commands) {
 
     // Add three wait actions with custom config
     commands
-        .action_builder(
-            id,
-            AddConfig {
-                order: AddOrder::Back, // Add each action to the back of the queue
-                start: true,           // Start action if nothing is currently running
-                repeat: true,          // Repeat each action when it has finished
-            },
-        )
+        .action(id)
+        .config(AddConfig {
+            order: AddOrder::Back, // Add each action to the back of the queue
+            start: true,           // Start action if nothing is currently running
+            repeat: true,          // Repeat each action when it has finished
+        })
         .push(WaitAction(1.0))
         .push(WaitAction(2.0))
         .push(WaitAction(3.0))
@@ -57,7 +55,7 @@ fn wait(mut wait_q: Query<(Entity, &mut Wait)>, time: Res<Time>, mut commands: C
         wait.0 -= time.delta_seconds();
         if wait.0 <= 0.0 {
             // To signal that an action has finished, the next action method must be called.
-            commands.next_action(actor);
+            commands.action(actor).next();
         }
     }
 }

--- a/examples/stop.rs
+++ b/examples/stop.rs
@@ -29,7 +29,7 @@ fn setup(mut commands: Commands) {
 
     // Add count and quit action with default config
     commands
-        .action_builder(id, AddConfig::default())
+        .action(id)
         .push(CountAction::default())
         .push(QuitAction)
         .submit();
@@ -70,19 +70,18 @@ fn count(mut count_q: Query<(Entity, &mut Count)>, mut commands: Commands) {
 
         if count.0 == 10 {
             // Stop current action and add InterruptAction to the front.
-            commands.stop_action(actor);
-            commands.add_action(
-                actor,
-                InterruptAction,
-                AddConfig {
+            commands
+                .action(actor)
+                .stop()
+                .config(AddConfig {
                     order: AddOrder::Front,
                     start: true,
                     repeat: false,
-                },
-            );
+                })
+                .add(InterruptAction);
         } else if count.0 == 20 {
             // Count has finished. Issue next action.
-            commands.next_action(actor);
+            commands.action(actor).next();
         }
     }
 }
@@ -141,6 +140,6 @@ fn on_interrupt_update(
     *timer += time.delta_seconds();
 
     if *timer >= 3.0 {
-        commands.next_action(actor_q.single());
+        commands.action(actor_q.single()).next();
     }
 }

--- a/examples/stop.rs
+++ b/examples/stop.rs
@@ -41,7 +41,7 @@ struct CountAction {
 }
 
 impl Action for CountAction {
-    fn add(&mut self, entity: Entity, world: &mut World, _commands: &mut ActionCommands) {
+    fn start(&mut self, entity: Entity, world: &mut World, _commands: &mut ActionCommands) {
         let count = self.current_count.unwrap_or(0);
         world.entity_mut(entity).insert(Count(count));
     }
@@ -52,7 +52,7 @@ impl Action for CountAction {
 
     fn stop(&mut self, entity: Entity, world: &mut World) {
         // When stop is called, we need to store the current count progress.
-        // This is so we can continue the count when add() is called again.
+        // This is so we can continue the count when start() is called again.
         let count = world.get::<Count>(entity).unwrap();
         self.current_count = Some(count.0);
         self.remove(entity, world);
@@ -89,7 +89,7 @@ fn count(mut count_q: Query<(Entity, &mut Count)>, mut commands: Commands) {
 struct QuitAction;
 
 impl Action for QuitAction {
-    fn add(&mut self, _entity: Entity, world: &mut World, _commands: &mut ActionCommands) {
+    fn start(&mut self, _entity: Entity, world: &mut World, _commands: &mut ActionCommands) {
         let mut app_exit_ev = world.resource_mut::<Events<AppExit>>();
         app_exit_ev.send(AppExit);
     }
@@ -101,7 +101,7 @@ impl Action for QuitAction {
 struct InterruptAction;
 
 impl Action for InterruptAction {
-    fn add(&mut self, entity: Entity, world: &mut World, _commands: &mut ActionCommands) {
+    fn start(&mut self, entity: Entity, world: &mut World, _commands: &mut ActionCommands) {
         println!("\n---------- Interrupt event! ----------");
         println!("Just wait a few seconds and actions will continue again.\n");
 

--- a/src/action_commands.rs
+++ b/src/action_commands.rs
@@ -1,14 +1,15 @@
 use bevy_ecs::prelude::*;
 
-use crate::{world::EntityWorldActionsExt, *};
+use crate::*;
 
-/// Commands for modifying actions in the [`Action`] trait.
+/// Commands for modifying actions inside the [`Action`] trait.
 #[derive(Default)]
 pub struct ActionCommands(Vec<ActionCommand>);
 
 impl ActionCommands {
-    pub fn action(&mut self, entity: Entity) -> EntityActionCommands {
-        EntityActionCommands {
+    /// Returns an [`EntityActions`] for the requested [`Entity`].
+    pub fn action(&mut self, entity: Entity) -> EntityActions {
+        EntityActions {
             entity,
             config: AddConfig::default(),
             actions: Vec::new(),
@@ -17,7 +18,8 @@ impl ActionCommands {
     }
 }
 
-pub struct EntityActionCommands<'a> {
+/// Modify actions using [`ActionCommands`].
+pub struct EntityActions<'a> {
     entity: Entity,
     config: AddConfig,
     actions: Vec<(Box<dyn Action>, AddConfig)>,
@@ -31,7 +33,7 @@ enum ActionCommand {
     Clear(Entity),
 }
 
-impl ActionsExt for EntityActionCommands<'_> {
+impl ModifyActionsExt for EntityActions<'_> {
     fn config(mut self, config: AddConfig) -> Self {
         self.config = config;
         self

--- a/src/action_commands.rs
+++ b/src/action_commands.rs
@@ -87,17 +87,17 @@ impl ActionCommands {
     pub(super) fn apply(self, world: &mut World) {
         for cmd in self.0 {
             match cmd {
-                ActionCommand::Add(actor, action, config) => {
-                    world.action(actor).config(config).add(action);
+                ActionCommand::Add(entity, action, config) => {
+                    world.action(entity).config(config).add(action);
                 }
-                ActionCommand::Next(actor) => {
-                    world.action(actor).next();
+                ActionCommand::Next(entity) => {
+                    world.action(entity).next();
                 }
-                ActionCommand::Stop(actor) => {
-                    world.action(actor).stop();
+                ActionCommand::Stop(entity) => {
+                    world.action(entity).stop();
                 }
-                ActionCommand::Clear(actor) => {
-                    world.action(actor).clear();
+                ActionCommand::Clear(entity) => {
+                    world.action(entity).clear();
                 }
             }
         }

--- a/src/action_commands.rs
+++ b/src/action_commands.rs
@@ -1,6 +1,6 @@
 use bevy_ecs::prelude::*;
 
-use crate::{world::ActionsWorldExt, *};
+use crate::{world::EntityWorldActionsExt, *};
 
 /// Commands for modifying actions in the [`Action`] trait.
 #[derive(Default)]
@@ -31,7 +31,7 @@ enum ActionCommand {
     Clear(Entity),
 }
 
-impl<'a> ActionsExt for EntityActionCommands<'a> {
+impl ActionsExt for EntityActionCommands<'_> {
     fn config(mut self, config: AddConfig) -> Self {
         self.config = config;
         self
@@ -86,16 +86,16 @@ impl ActionCommands {
         for cmd in self.0 {
             match cmd {
                 ActionCommand::Add(actor, action, config) => {
-                    world.add_action(actor, action, config);
-                }
-                ActionCommand::Stop(actor) => {
-                    world.stop_action(actor);
+                    world.action(actor).config(config).add(action);
                 }
                 ActionCommand::Next(actor) => {
-                    world.next_action(actor);
+                    world.action(actor).next();
+                }
+                ActionCommand::Stop(actor) => {
+                    world.action(actor).stop();
                 }
                 ActionCommand::Clear(actor) => {
-                    world.clear_actions(actor);
+                    world.action(actor).clear();
                 }
             }
         }

--- a/src/commands.rs
+++ b/src/commands.rs
@@ -1,13 +1,80 @@
-use bevy_ecs::{
-    prelude::*,
-    system::{Command, CommandQueue},
-};
+use bevy_ecs::{prelude::*, system::Command};
 
 use crate::{world::ActionsWorldExt, *};
 
-//
-// Trait impls
-//
+pub trait EntityActionsExt<'w, 's> {
+    fn action<'a>(&'a mut self, entity: Entity) -> EntityActions<'w, 's, 'a>;
+}
+
+impl<'w, 's> EntityActionsExt<'w, 's> for Commands<'w, 's> {
+    fn action<'a>(&'a mut self, entity: Entity) -> EntityActions<'w, 's, 'a> {
+        EntityActions {
+            entity,
+            config: AddConfig::default(),
+            actions: Vec::new(),
+            commands: self,
+        }
+    }
+}
+
+pub struct EntityActions<'w, 's, 'a> {
+    entity: Entity,
+    config: AddConfig,
+    actions: Vec<(Box<dyn Action>, AddConfig)>,
+    commands: &'a mut Commands<'w, 's>,
+}
+
+impl<'w, 's, 'a> ActionsExt for EntityActions<'w, 's, 'a> {
+    fn config(mut self, cfg: AddConfig) -> Self {
+        self.config = cfg;
+        self
+    }
+
+    fn add(self, action: impl IntoAction) -> Self {
+        self.commands.add(AddAction {
+            actor: self.entity,
+            config: self.config,
+            action: action.into_boxed(),
+        });
+        self
+    }
+
+    fn next(self) -> Self {
+        self.commands.add(NextAction { actor: self.entity });
+        self
+    }
+
+    fn stop(self) -> Self {
+        self.commands.add(StopAction { actor: self.entity });
+        self
+    }
+
+    fn clear(self) -> Self {
+        self.commands.add(ClearActions { actor: self.entity });
+        self
+    }
+
+    fn push(mut self, action: impl IntoAction) -> Self {
+        self.actions.push((action.into_boxed(), self.config));
+        self
+    }
+
+    fn reverse(mut self) -> Self {
+        self.actions.reverse();
+        self
+    }
+
+    fn submit(mut self) -> Self {
+        for (action, config) in self.actions.drain(..) {
+            self.commands.add(AddAction {
+                actor: self.entity,
+                config,
+                action,
+            });
+        }
+        self
+    }
+}
 
 struct AddAction {
     actor: Entity,
@@ -48,120 +115,5 @@ impl Command for NextAction {
 impl Command for ClearActions {
     fn write(self, world: &mut World) {
         world.clear_actions(self.actor);
-    }
-}
-
-impl AddActionExt for Commands<'_, '_> {
-    fn add_action(&mut self, actor: Entity, action: impl IntoAction, config: AddConfig) {
-        self.add(AddAction {
-            actor,
-            config,
-            action: action.into_boxed(),
-        });
-    }
-}
-
-impl StopActionExt for Commands<'_, '_> {
-    fn stop_action(&mut self, actor: Entity) {
-        self.add(StopAction { actor });
-    }
-}
-
-impl NextActionExt for Commands<'_, '_> {
-    fn next_action(&mut self, actor: Entity) {
-        self.add(NextAction { actor });
-    }
-}
-
-impl ClearActionsExt for Commands<'_, '_> {
-    fn clear_actions(&mut self, actor: Entity) {
-        self.add(ClearActions { actor });
-    }
-}
-
-//
-// Action builder
-//
-
-/// Extension trait for `action_builder` method on [`Commands`].
-pub trait ActionBuilderCommandsExt<'w, 's, 'c> {
-    /// Create and return [`ActionBuilderCommands`] for building actions.
-    fn action_builder(
-        &'c mut self,
-        actor: Entity,
-        config: AddConfig,
-    ) -> ActionBuilderCommands<'w, 's, 'c>;
-}
-
-impl<'w, 's, 'c> ActionBuilderCommandsExt<'w, 's, 'c> for Commands<'w, 's> {
-    fn action_builder(
-        &'c mut self,
-        actor: Entity,
-        config: AddConfig,
-    ) -> ActionBuilderCommands<'w, 's, 'c> {
-        ActionBuilderCommands {
-            actor,
-            config,
-            actions: Vec::default(),
-            commands: self,
-        }
-    }
-}
-
-/// [`Action`] builder struct for [`Commands`].
-pub struct ActionBuilderCommands<'w, 's, 'c> {
-    actor: Entity,
-    config: AddConfig,
-    actions: Vec<Box<dyn Action>>,
-    commands: &'c mut Commands<'w, 's>,
-}
-
-impl<'w, 's, 'c> ActionBuilderCommands<'w, 's, 'c> {
-    /// Push an [`Action`] to the builder list.
-    /// No [`Action`] will be applied until [`ActionBuilderCommands::submit`] is called.
-    pub fn push(mut self, action: impl IntoAction) -> Self {
-        self.actions.push(action.into_boxed());
-        self
-    }
-
-    /// Reverse the order for the currently pushed actions.
-    pub fn reverse(mut self) -> Self {
-        self.actions.reverse();
-        self
-    }
-
-    /// Submit the pushed actions.
-    pub fn submit(self) {
-        self.commands.add(SubmitActions {
-            actor: self.actor,
-            config: self.config,
-            actions: self.actions,
-        });
-    }
-}
-
-struct SubmitActions {
-    actor: Entity,
-    config: AddConfig,
-    actions: Vec<Box<dyn Action>>,
-}
-
-impl Command for SubmitActions {
-    fn write(self, world: &mut World) {
-        let mut command_queue = CommandQueue::default();
-        let mut commands = Commands::new(&mut command_queue, world);
-
-        let actor = self.actor;
-        let config = self.config;
-
-        for action in self.actions {
-            commands.add(AddAction {
-                actor,
-                config,
-                action,
-            });
-        }
-
-        command_queue.apply(world);
     }
 }

--- a/src/commands.rs
+++ b/src/commands.rs
@@ -2,13 +2,15 @@ use bevy_ecs::{prelude::*, system::Command};
 
 use crate::{world::EntityWorldActionsExt, *};
 
-pub trait EntityActionsExt<'w, 's> {
-    fn action(&mut self, entity: Entity) -> EntityActions<'w, 's, '_>;
+/// Extension method on [`Commands`] for modifying actions.
+pub trait EntityCommandsActionsExt<'w, 's> {
+    /// Returns an [`EntityCommandsActions`] for the requested [`Entity`].
+    fn action(&mut self, entity: Entity) -> EntityCommandsActions<'w, 's, '_>;
 }
 
-impl<'w, 's> EntityActionsExt<'w, 's> for Commands<'w, 's> {
-    fn action(&mut self, entity: Entity) -> EntityActions<'w, 's, '_> {
-        EntityActions {
+impl<'w, 's> EntityCommandsActionsExt<'w, 's> for Commands<'w, 's> {
+    fn action(&mut self, entity: Entity) -> EntityCommandsActions<'w, 's, '_> {
+        EntityCommandsActions {
             entity,
             config: AddConfig::default(),
             actions: Vec::new(),
@@ -17,14 +19,15 @@ impl<'w, 's> EntityActionsExt<'w, 's> for Commands<'w, 's> {
     }
 }
 
-pub struct EntityActions<'w, 's, 'a> {
+/// Modify actions using [`Commands`].
+pub struct EntityCommandsActions<'w, 's, 'a> {
     entity: Entity,
     config: AddConfig,
     actions: Vec<(Box<dyn Action>, AddConfig)>,
     commands: &'a mut Commands<'w, 's>,
 }
 
-impl<'w, 's> ActionsExt for EntityActions<'w, 's, '_> {
+impl<'w, 's> ModifyActionsExt for EntityCommandsActions<'w, 's, '_> {
     fn config(mut self, config: AddConfig) -> Self {
         self.config = config;
         self

--- a/src/commands.rs
+++ b/src/commands.rs
@@ -25,8 +25,8 @@ pub struct EntityActions<'w, 's, 'a> {
 }
 
 impl<'w, 's, 'a> ActionsExt for EntityActions<'w, 's, 'a> {
-    fn config(mut self, cfg: AddConfig) -> Self {
-        self.config = cfg;
+    fn config(mut self, config: AddConfig) -> Self {
+        self.config = config;
         self
     }
 

--- a/src/commands.rs
+++ b/src/commands.rs
@@ -1,6 +1,6 @@
 use bevy_ecs::{prelude::*, system::Command};
 
-use crate::{world::EntityWorldActionsExt, *};
+use crate::*;
 
 /// Extension method on [`Commands`] for modifying actions.
 pub trait EntityCommandsActionsExt<'w, 's> {

--- a/src/commands.rs
+++ b/src/commands.rs
@@ -35,7 +35,7 @@ impl<'w, 's> ModifyActionsExt for EntityCommandsActions<'w, 's, '_> {
 
     fn add(self, action: impl IntoAction) -> Self {
         self.commands.add(AddAction {
-            actor: self.entity,
+            entity: self.entity,
             config: self.config,
             action: action.into_boxed(),
         });
@@ -43,17 +43,23 @@ impl<'w, 's> ModifyActionsExt for EntityCommandsActions<'w, 's, '_> {
     }
 
     fn next(self) -> Self {
-        self.commands.add(NextAction { actor: self.entity });
+        self.commands.add(NextAction {
+            entity: self.entity,
+        });
         self
     }
 
     fn stop(self) -> Self {
-        self.commands.add(StopAction { actor: self.entity });
+        self.commands.add(StopAction {
+            entity: self.entity,
+        });
         self
     }
 
     fn clear(self) -> Self {
-        self.commands.add(ClearActions { actor: self.entity });
+        self.commands.add(ClearActions {
+            entity: self.entity,
+        });
         self
     }
 
@@ -70,7 +76,7 @@ impl<'w, 's> ModifyActionsExt for EntityCommandsActions<'w, 's, '_> {
     fn submit(mut self) -> Self {
         for (action, config) in self.actions.drain(..) {
             self.commands.add(AddAction {
-                actor: self.entity,
+                entity: self.entity,
                 config,
                 action,
             });
@@ -80,27 +86,27 @@ impl<'w, 's> ModifyActionsExt for EntityCommandsActions<'w, 's, '_> {
 }
 
 struct AddAction {
-    actor: Entity,
+    entity: Entity,
     config: AddConfig,
     action: Box<dyn Action>,
 }
 
 struct NextAction {
-    actor: Entity,
+    entity: Entity,
 }
 
 struct StopAction {
-    actor: Entity,
+    entity: Entity,
 }
 
 struct ClearActions {
-    actor: Entity,
+    entity: Entity,
 }
 
 impl Command for AddAction {
     fn write(self, world: &mut World) {
         world
-            .action(self.actor)
+            .action(self.entity)
             .config(self.config)
             .add(self.action);
     }
@@ -108,18 +114,18 @@ impl Command for AddAction {
 
 impl Command for NextAction {
     fn write(self, world: &mut World) {
-        world.action(self.actor).next();
+        world.action(self.entity).next();
     }
 }
 
 impl Command for StopAction {
     fn write(self, world: &mut World) {
-        world.action(self.actor).stop();
+        world.action(self.entity).stop();
     }
 }
 
 impl Command for ClearActions {
     fn write(self, world: &mut World) {
-        world.action(self.actor).clear();
+        world.action(self.entity).clear();
     }
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,4 +1,4 @@
-#![deny(missing_docs)]
+// #![warn(missing_docs)]
 
 //! # Bevy Sequential Actions
 //!

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -166,6 +166,46 @@ mod tests {
 
         world
             .action(e)
+            .add(EmptyAction)
+            .add(EmptyAction)
+            .add(EmptyAction);
+
+        assert!(world.get::<CurrentAction>(e).unwrap().0.is_some());
+        assert!(world.get::<ActionQueue>(e).unwrap().0.len() == 2);
+
+        world.action(e).next();
+
+        assert!(world.get::<CurrentAction>(e).unwrap().0.is_some());
+        assert!(world.get::<ActionQueue>(e).unwrap().0.len() == 1);
+
+        world.action(e).next();
+
+        assert!(world.get::<CurrentAction>(e).unwrap().0.is_some());
+        assert!(world.get::<ActionQueue>(e).unwrap().0.len() == 0);
+
+        world.action(e).next();
+
+        assert!(world.get::<CurrentAction>(e).unwrap().0.is_none());
+        assert!(world.get::<ActionQueue>(e).unwrap().0.len() == 0);
+    }
+
+    #[test]
+    fn push() {
+        let mut world = World::new();
+
+        let e = world.spawn().insert_bundle(ActionsBundle::default()).id();
+
+        world
+            .action(e)
+            .push(EmptyAction)
+            .push(EmptyAction)
+            .push(EmptyAction);
+
+        assert!(world.get::<CurrentAction>(e).unwrap().0.is_none());
+        assert!(world.get::<ActionQueue>(e).unwrap().0.len() == 0);
+
+        world
+            .action(e)
             .push(EmptyAction)
             .push(EmptyAction)
             .push(EmptyAction)
@@ -225,12 +265,11 @@ mod tests {
 
         world
             .action(e)
-            .push(EmptyAction)
-            .push(EmptyAction)
-            .push(EmptyAction)
-            .push(EmptyAction)
-            .push(EmptyAction)
-            .submit();
+            .add(EmptyAction)
+            .add(EmptyAction)
+            .add(EmptyAction)
+            .add(EmptyAction)
+            .add(EmptyAction);
 
         assert!(world.get::<CurrentAction>(e).unwrap().0.is_some());
         assert!(world.get::<ActionQueue>(e).unwrap().0.len() == 4);

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -50,7 +50,7 @@
 //! struct WaitAction(f32);
 //!
 //! impl Action for WaitAction {
-//!     fn add(&mut self, entity: Entity, world: &mut World, _commands: &mut ActionCommands) {
+//!     fn start(&mut self, entity: Entity, world: &mut World, _commands: &mut ActionCommands) {
 //!         world.entity_mut(entity).insert(Wait(self.0));
 //!     }
 //!
@@ -153,7 +153,7 @@ mod tests {
 
     struct EmptyAction;
     impl Action for EmptyAction {
-        fn add(&mut self, _entity: Entity, _world: &mut World, _commands: &mut ActionCommands) {}
+        fn start(&mut self, _entity: Entity, _world: &mut World, _commands: &mut ActionCommands) {}
         fn remove(&mut self, _entity: Entity, _world: &mut World) {}
         fn stop(&mut self, _entity: Entity, _world: &mut World) {}
     }
@@ -274,7 +274,7 @@ mod tests {
     fn despawn() {
         struct DespawnAction;
         impl Action for DespawnAction {
-            fn add(&mut self, entity: Entity, world: &mut World, _commands: &mut ActionCommands) {
+            fn start(&mut self, entity: Entity, world: &mut World, _commands: &mut ActionCommands) {
                 world.despawn(entity);
             }
             fn remove(&mut self, _entity: Entity, _world: &mut World) {}

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -41,9 +41,8 @@
 //!             // Repeat the action
 //!             repeat: false,
 //!         })
-//!         .push(WaitAction(2.0))
-//!         .push(WaitAction(3.0))
-//!         .submit();
+//!         .add(WaitAction(2.0))
+//!         .add(WaitAction(3.0));
 //! }
 //!
 //! struct WaitAction(f32);

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -8,8 +8,10 @@
 //!
 //! ## Getting Started
 //!
-//! An action is anything that implements the [`Action`] trait, and can be added to any [`Entity`] that contains the
-//! [`ActionsBundle`]. Each action must signal when they are finished, which is done by calling the [`next`](ModifyActionsExt::next) method.
+//! An action is anything that implements the [`Action`] trait,
+//! and can be added to any [`Entity`] that contains the [`ActionsBundle`].
+//! Each action must signal when they are finished,
+//! which is done by calling the [`next`](ModifyActionsExt::next) method.
 //!
 //! ```rust
 //! use bevy::prelude::*;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -49,16 +49,16 @@
 //! struct WaitAction(f32);
 //!
 //! impl Action for WaitAction {
-//!     fn add(&mut self, actor: Entity, world: &mut World, _commands: &mut ActionCommands) {
-//!         world.entity_mut(actor).insert(Wait(self.0));
+//!     fn add(&mut self, entity: Entity, world: &mut World, _commands: &mut ActionCommands) {
+//!         world.entity_mut(entity).insert(Wait(self.0));
 //!     }
 //!
-//!     fn remove(&mut self, actor: Entity, world: &mut World) {
-//!         world.entity_mut(actor).remove::<Wait>();
+//!     fn remove(&mut self, entity: Entity, world: &mut World) {
+//!         world.entity_mut(entity).remove::<Wait>();
 //!     }
 //!
-//!     fn stop(&mut self, actor: Entity, world: &mut World) {
-//!         self.remove(actor, world);
+//!     fn stop(&mut self, entity: Entity, world: &mut World) {
+//!         self.remove(entity, world);
 //!     }
 //! }
 //!
@@ -66,11 +66,11 @@
 //! struct Wait(f32);
 //!
 //! fn wait(mut wait_q: Query<(Entity, &mut Wait)>, time: Res<Time>, mut commands: Commands) {
-//!     for (actor, mut wait) in wait_q.iter_mut() {
+//!     for (entity, mut wait) in wait_q.iter_mut() {
 //!         wait.0 -= time.delta_seconds();
 //!         if wait.0 <= 0.0 {
 //!             // Action is finished, issue next.
-//!             commands.action(actor).next();
+//!             commands.action(entity).next();
 //!         }
 //!     }
 //! }
@@ -152,9 +152,9 @@ mod tests {
 
     struct EmptyAction;
     impl Action for EmptyAction {
-        fn add(&mut self, _actor: Entity, _world: &mut World, _commands: &mut ActionCommands) {}
-        fn remove(&mut self, _actor: Entity, _world: &mut World) {}
-        fn stop(&mut self, _actor: Entity, _world: &mut World) {}
+        fn add(&mut self, _entity: Entity, _world: &mut World, _commands: &mut ActionCommands) {}
+        fn remove(&mut self, _entity: Entity, _world: &mut World) {}
+        fn stop(&mut self, _entity: Entity, _world: &mut World) {}
     }
 
     #[test]
@@ -273,11 +273,11 @@ mod tests {
     fn despawn() {
         struct DespawnAction;
         impl Action for DespawnAction {
-            fn add(&mut self, actor: Entity, world: &mut World, _commands: &mut ActionCommands) {
-                world.despawn(actor);
+            fn add(&mut self, entity: Entity, world: &mut World, _commands: &mut ActionCommands) {
+                world.despawn(entity);
             }
-            fn remove(&mut self, _actor: Entity, _world: &mut World) {}
-            fn stop(&mut self, _actor: Entity, _world: &mut World) {}
+            fn remove(&mut self, _entity: Entity, _world: &mut World) {}
+            fn stop(&mut self, _entity: Entity, _world: &mut World) {}
         }
 
         let mut world = World::new();

--- a/src/traits.rs
+++ b/src/traits.rs
@@ -12,7 +12,7 @@ use crate::*;
 /// struct EmptyAction;
 ///
 /// impl Action for EmptyAction {
-///     fn add(&mut self, entity: Entity, world: &mut World, commands: &mut ActionCommands) {
+///     fn start(&mut self, entity: Entity, world: &mut World, commands: &mut ActionCommands) {
 ///         // Action is finished, issue next.
 ///         commands.action(entity).next();
 ///     }
@@ -23,7 +23,7 @@ use crate::*;
 /// ```
 pub trait Action: Send + Sync {
     /// The method that is called when an [`action`](Action) is started.
-    fn add(&mut self, entity: Entity, world: &mut World, commands: &mut ActionCommands);
+    fn start(&mut self, entity: Entity, world: &mut World, commands: &mut ActionCommands);
     /// The method that is called when an [`action`](Action) is removed.
     fn remove(&mut self, entity: Entity, world: &mut World);
     /// The method that is called when an [`action`](Action) is stopped.

--- a/src/traits.rs
+++ b/src/traits.rs
@@ -77,7 +77,7 @@ pub trait ModifyActionsExt {
     /// [`Removes`](Action::remove) the currently running action, and clears any remaining.
     fn clear(self) -> Self;
 
-    /// Push an [`action`](Action) with the current [`config`](AddConfig) to a list.
+    /// Push an [`action`](Action) to a list with the current [`config`](AddConfig).
     /// Pushed actions __will not__ be added to the queue until [`submit`](Self::submit) is called.
     fn push(self, action: impl IntoAction) -> Self;
 

--- a/src/traits.rs
+++ b/src/traits.rs
@@ -12,22 +12,22 @@ use crate::*;
 /// struct EmptyAction;
 ///
 /// impl Action for EmptyAction {
-///     fn add(&mut self, actor: Entity, world: &mut World, commands: &mut ActionCommands) {
+///     fn add(&mut self, entity: Entity, world: &mut World, commands: &mut ActionCommands) {
 ///         // Action is finished, issue next.
-///         commands.action(actor).next();
+///         commands.action(entity).next();
 ///     }
 ///
-///     fn remove(&mut self, actor: Entity, world: &mut World) {}
-///     fn stop(&mut self, actor: Entity, world: &mut World) {}
+///     fn remove(&mut self, entity: Entity, world: &mut World) {}
+///     fn stop(&mut self, entity: Entity, world: &mut World) {}
 /// }
 /// ```
 pub trait Action: Send + Sync {
     /// The method that is called when an [`action`](Action) is started.
-    fn add(&mut self, actor: Entity, world: &mut World, commands: &mut ActionCommands);
+    fn add(&mut self, entity: Entity, world: &mut World, commands: &mut ActionCommands);
     /// The method that is called when an [`action`](Action) is removed.
-    fn remove(&mut self, actor: Entity, world: &mut World);
+    fn remove(&mut self, entity: Entity, world: &mut World);
     /// The method that is called when an [`action`](Action) is stopped.
-    fn stop(&mut self, actor: Entity, world: &mut World);
+    fn stop(&mut self, entity: Entity, world: &mut World);
 }
 
 /// Conversion into an [`Action`].
@@ -66,7 +66,7 @@ pub trait ModifyActionsExt {
     /// Stops the current [`action`](Action). This is done by [`removing`](Action::remove) the currently running action,
     /// and adding it to the **front** of the queue again.
     ///
-    /// **Note**: when stopping an action, you need to manually resume the actions.
+    /// **Note:** when stopping an action, you need to manually resume again.
     /// This can be done by calling [`next`](Self::next), which will resume the same action that was stopped,
     /// or you could add a new action to the **front** of the queue beforehand.
     /// When adding a new action, either specify in [`config`](AddConfig) that the action should [`start`](AddConfig::start),

--- a/src/traits.rs
+++ b/src/traits.rs
@@ -23,6 +23,17 @@ impl IntoAction for Box<dyn Action> {
     }
 }
 
+pub trait ActionsExt {
+    fn config(self, config: AddConfig) -> Self;
+    fn add(self, action: impl IntoAction) -> Self;
+    fn stop(self) -> Self;
+    fn next(self) -> Self;
+    fn clear(self) -> Self;
+    fn push(self, action: impl IntoAction) -> Self;
+    fn reverse(self) -> Self;
+    fn submit(self) -> Self;
+}
+
 /// Extension trait for `add_action` method on [`ActionCommands`] and [`Commands`].
 pub trait AddActionExt {
     /// Add `action` to entity `actor` with the configuration `config`.

--- a/src/traits.rs
+++ b/src/traits.rs
@@ -1,6 +1,34 @@
-use bevy_ecs::prelude::*;
-
 use crate::*;
+
+/// The trait that all actions must implement.
+///
+/// # Example
+///
+/// An empty action that does nothing.
+/// All actions must declare when they are done.
+/// This is done by calling [`next`](ModifyActionsExt::next) from either [`ActionCommands`] or [`Commands`].
+///
+/// ```rust
+/// struct EmptyAction;
+///
+/// impl Action for EmptyAction {
+///     fn add(&mut self, actor: Entity, world: &mut World, commands: &mut ActionCommands) {
+///         // Action is finished, issue next.
+///         commands.action(actor).next();
+///     }
+///
+///     fn remove(&mut self, actor: Entity, world: &mut World) {}
+///     fn stop(&mut self, actor: Entity, world: &mut World) {}
+/// }
+/// ```
+pub trait Action: Send + Sync {
+    /// The method that is called when an [`action`](Action) is started.
+    fn add(&mut self, actor: Entity, world: &mut World, commands: &mut ActionCommands);
+    /// The method that is called when an [`action`](Action) is removed.
+    fn remove(&mut self, actor: Entity, world: &mut World);
+    /// The method that is called when an [`action`](Action) is stopped.
+    fn stop(&mut self, actor: Entity, world: &mut World);
+}
 
 /// Conversion into an [`Action`].
 pub trait IntoAction {
@@ -23,81 +51,39 @@ impl IntoAction for Box<dyn Action> {
     }
 }
 
-pub trait ActionsExt {
+/// Extension methods for modifying actions.
+pub trait ModifyActionsExt {
+    /// Sets the current [`config`](AddConfig) for actions to be added.
     fn config(self, config: AddConfig) -> Self;
+
+    /// Adds an [`action`](Action) with the current [`config`](AddConfig).
     fn add(self, action: impl IntoAction) -> Self;
+
+    /// Starts the next [`action`](Action) in the queue. This is done by [`removing`](Action::remove) the currently running action,
+    /// and retrieving the next action in the queue list.
     fn next(self) -> Self;
-    fn stop(self) -> Self;
-    fn clear(self) -> Self;
-    fn push(self, action: impl IntoAction) -> Self;
-    fn reverse(self) -> Self;
-    fn submit(self) -> Self;
-}
 
-/// Extension trait for `add_action` method on [`ActionCommands`] and [`Commands`].
-pub trait AddActionExt {
-    /// Add `action` to entity `actor` with the configuration `config`.
-    fn add_action(&mut self, actor: Entity, action: impl IntoAction, config: AddConfig);
-}
-
-/// Extension trait for `stop_action` method on [`ActionCommands`] and [`Commands`].
-pub trait StopActionExt {
-    /// Stop the current action for entity `actor`. This is done by removing the currently running action,
-    /// and pushing it to the **front** of the queue again.
+    /// Stops the current [`action`](Action). This is done by [`removing`](Action::remove) the currently running action,
+    /// and adding it to the **front** of the queue again.
     ///
     /// **Note**: when stopping an action, you need to manually resume the actions.
-    /// This can be done by calling `next_action`, which will resume the same action that was stopped,
+    /// This can be done by calling [`next`](Self::next), which will resume the same action that was stopped,
     /// or you could add a new action to the **front** of the queue beforehand.
-    /// When adding a new action, either specify in [`AddConfig`] that the action should start,
-    /// or manually call `next_action` afterwards, but not both, as that will trigger two
-    /// consecutive `next_action` calls.
-    ///
-    /// # Example
-    ///
-    /// Stopping an [`Action`] and adding a new one with `start: true` in [`AddConfig`]:
-    ///
-    /// ```rust
-    /// commands.stop_action(actor);
-    /// commands.add_action(
-    ///     actor,
-    ///     MyAction,
-    ///     AddConfig {
-    ///         order: AddOrder::Front,
-    ///         start: true,
-    ///         repeat: false,
-    ///     },
-    /// );
-    /// // No need to call next_action here
-    /// ```
-    ///
-    /// Stopping an [`Action`] and manually calling `next_action`:
-    ///
-    /// ```rust
-    /// commands.stop_action(actor);
-    /// commands.add_action(
-    ///     actor,
-    ///     MyAction,
-    ///     AddConfig {
-    ///         order: AddOrder::Front,
-    ///         start: false,
-    ///         repeat: false,
-    ///     },
-    /// );
-    /// // Must call next_action here
-    /// commands.next_action(actor);
-    /// ```
-    fn stop_action(&mut self, actor: Entity);
-}
+    /// When adding a new action, either specify in [`config`](AddConfig) that the action should [`start`](AddConfig::start),
+    /// or manually call [`next`](Self::next) afterwards, __but not both__, as that will trigger two
+    /// consecutive [`next`](Self::next) calls.
+    fn stop(self) -> Self;
 
-/// Extension trait for `next_action` method on [`ActionCommands`] and [`Commands`].
-pub trait NextActionExt {
-    /// Start next action for entity `actor`. This is done by removing the currently running action,
-    /// and retrieving the next action in the queue list.
-    fn next_action(&mut self, actor: Entity);
-}
+    /// [`Removes`](Action::remove) the currently running action, and clears any remaining.
+    fn clear(self) -> Self;
 
-/// Extension trait for `clear_actions` method on [`ActionCommands`] and [`Commands`].
-pub trait ClearActionsExt {
-    /// Remove the currently running action for entity `actor`, and clear any remaining.
-    fn clear_actions(&mut self, actor: Entity);
+    /// Push an [`action`](Action) with the current [`config`](AddConfig) to a list.
+    /// Pushed actions __will not__ be added to the queue until [`submit`](Self::submit) is called.
+    fn push(self, action: impl IntoAction) -> Self;
+
+    /// Reverse the order of the [`pushed`](Self::push) actions.
+    fn reverse(self) -> Self;
+
+    /// Submit the [`pushed`](Self::push) actions by draining the list and adding them to the queue.
+    fn submit(self) -> Self;
 }

--- a/src/traits.rs
+++ b/src/traits.rs
@@ -26,8 +26,8 @@ impl IntoAction for Box<dyn Action> {
 pub trait ActionsExt {
     fn config(self, config: AddConfig) -> Self;
     fn add(self, action: impl IntoAction) -> Self;
-    fn stop(self) -> Self;
     fn next(self) -> Self;
+    fn stop(self) -> Self;
     fn clear(self) -> Self;
     fn push(self, action: impl IntoAction) -> Self;
     fn reverse(self) -> Self;

--- a/src/world.rs
+++ b/src/world.rs
@@ -13,16 +13,16 @@ pub trait EntityWorldActionsExt {
     /// ```rust
     /// struct UselessAction;
     /// impl Action for UselessAction {
-    ///     fn add(&mut self, actor: Entity, world: &mut World, commands: &mut ActionCommands) {
+    ///     fn add(&mut self, entity: Entity, world: &mut World, commands: &mut ActionCommands) {
     ///         // Bad
-    ///         world.action(actor).next();
+    ///         world.action(entity).next();
     ///
     ///         // Good
-    ///         commands.action(actor).next();
+    ///         commands.action(entity).next();
     ///     }
     ///
-    ///     fn remove(&mut self, actor: Entity, world: &mut World) {}
-    ///     fn stop(&mut self, actor: Entity, world: &mut World) {}
+    ///     fn remove(&mut self, entity: Entity, world: &mut World) {}
+    ///     fn stop(&mut self, entity: Entity, world: &mut World) {}
     /// }
     ///```
     fn action(&mut self, entity: Entity) -> EntityWorldActions;

--- a/src/world.rs
+++ b/src/world.rs
@@ -2,7 +2,9 @@ use bevy_ecs::{prelude::*, system::CommandQueue};
 
 use crate::*;
 
+/// Extension method on [`World`] for modifying actions.
 pub trait EntityWorldActionsExt {
+    /// Returns an [`EntityWorldActions`] for the requested [`Entity`].
     fn action(&mut self, entity: Entity) -> EntityWorldActions;
 }
 
@@ -17,6 +19,7 @@ impl EntityWorldActionsExt for World {
     }
 }
 
+/// Modify actions using [`World`].
 pub struct EntityWorldActions<'a> {
     entity: Entity,
     config: AddConfig,
@@ -24,7 +27,7 @@ pub struct EntityWorldActions<'a> {
     world: &'a mut World,
 }
 
-impl ActionsExt for EntityWorldActions<'_> {
+impl ModifyActionsExt for EntityWorldActions<'_> {
     fn config(mut self, config: AddConfig) -> Self {
         self.config = config;
         self

--- a/src/world.rs
+++ b/src/world.rs
@@ -5,6 +5,26 @@ use crate::*;
 /// Extension method on [`World`] for modifying actions.
 pub trait EntityWorldActionsExt {
     /// Returns an [`EntityWorldActions`] for the requested [`Entity`].
+    ///
+    /// ## Warning
+    ///
+    /// Do not modify actions using [`World`] inside the implementation of an [`Action`].
+    /// Actions need to be properly queued, which is what [`ActionCommands`] does.
+    /// ```rust
+    /// struct UselessAction;
+    /// impl Action for UselessAction {
+    ///     fn add(&mut self, actor: Entity, world: &mut World, commands: &mut ActionCommands) {
+    ///         // Bad
+    ///         world.action(actor).next();
+    ///
+    ///         // Good
+    ///         commands.action(actor).next();
+    ///     }
+    ///
+    ///     fn remove(&mut self, actor: Entity, world: &mut World) {}
+    ///     fn stop(&mut self, actor: Entity, world: &mut World) {}
+    /// }
+    ///```
     fn action(&mut self, entity: Entity) -> EntityWorldActions;
 }
 

--- a/src/world.rs
+++ b/src/world.rs
@@ -11,9 +11,10 @@ pub trait EntityWorldActionsExt {
     /// Do not modify actions using [`World`] inside the implementation of an [`Action`].
     /// Actions need to be properly queued, which is what [`ActionCommands`] does.
     /// ```rust
-    /// struct UselessAction;
-    /// impl Action for UselessAction {
-    ///     fn add(&mut self, entity: Entity, world: &mut World, commands: &mut ActionCommands) {
+    /// struct EmptyAction;
+    ///
+    /// impl Action for EmptyAction {
+    ///     fn start(&mut self, entity: Entity, world: &mut World, commands: &mut ActionCommands) {
     ///         // Bad
     ///         world.action(entity).next();
     ///
@@ -109,7 +110,7 @@ impl ModifyActionsExt for EntityWorldActions<'_> {
         // Set next action
         let mut commands = ActionCommands::default();
         if let Some((mut action, cfg)) = next {
-            action.add(self.entity, self.world, &mut commands);
+            action.start(self.entity, self.world, &mut commands);
             if let Some(mut current) = self.world.get_mut::<CurrentAction>(self.entity) {
                 current.0 = Some((action, cfg));
             }

--- a/src/world.rs
+++ b/src/world.rs
@@ -1,174 +1,163 @@
-use bevy_ecs::prelude::*;
+use bevy_ecs::{prelude::*, system::CommandQueue};
 
 use crate::*;
 
-/// Extension trait methods on [`World`] for modifying actions.
-pub trait ActionsWorldExt {
-    /// Add `action` to entity `actor` with the configuration `config`.
-    fn add_action(&mut self, actor: Entity, action: impl IntoAction, config: AddConfig);
-
-    /// Stop the current action for entity `actor`. This is done by removing the currently running action,
-    /// and pushing it to the **front** of the queue again.
-    ///
-    /// **Note**: when stopping an action, you need to manually resume the actions.
-    /// This can be done by calling `next_action`, which will resume the same action that was stopped,
-    /// or you could add a new action to the **front** of the queue beforehand.
-    /// When adding a new action, either specify in [`AddConfig`] that the action should start,
-    /// or manually call `next_action` afterwards, but not both, as that will trigger two
-    /// consecutive `next_action` calls.
-    ///
-    /// # Example
-    ///
-    /// Stopping an [`Action`] and adding a new one with `start: true` in [`AddConfig`]:
-    ///
-    /// ```rust
-    /// world.stop_action(actor);
-    /// world.add_action(
-    ///     actor,
-    ///     MyAction,
-    ///     AddConfig {
-    ///         order: AddOrder::Front,
-    ///         start: true,
-    ///         repeat: false,
-    ///     },
-    /// );
-    /// // No need to call next_action here
-    /// ```
-    ///
-    /// Stopping an [`Action`] and manually calling `next_action`:
-    ///
-    /// ```rust
-    /// world.stop_action(actor);
-    /// world.add_action(
-    ///     actor,
-    ///     MyAction,
-    ///     AddConfig {
-    ///         order: AddOrder::Front,
-    ///         start: false,
-    ///         repeat: false,
-    ///     },
-    /// );
-    /// // Must call next_action here
-    /// world.next_action(actor);
-    /// ```
-    fn stop_action(&mut self, actor: Entity);
-
-    /// Start next action for entity `actor`. This is done by removing the currently running action,
-    /// and retrieving the next action in the queue list.
-    fn next_action(&mut self, actor: Entity);
-
-    /// Remove the currently running action for entity `actor`, and clear any remaining.
-    fn clear_actions(&mut self, actor: Entity);
-
-    /// Create and return [`ActionBuilderWorld`] for building actions.
-    fn action_builder(&mut self, actor: Entity, config: AddConfig) -> ActionBuilderWorld;
+pub trait EntityWorldActionsExt {
+    fn action(&mut self, entity: Entity) -> EntityWorldActions;
 }
 
-impl ActionsWorldExt for World {
-    fn add_action(&mut self, actor: Entity, action: impl IntoAction, config: AddConfig) {
-        // Enqueue action
-        let action_tuple = (action.into_boxed(), config.into());
-        let mut actions = self.get_mut::<ActionQueue>(actor).unwrap();
-        match config.order {
-            AddOrder::Front => actions.0.push_front(action_tuple),
-            AddOrder::Back => actions.0.push_back(action_tuple),
-        }
-
-        // Start next action if nothing is currently running
-        if config.start {
-            let has_current = self.get::<CurrentAction>(actor).unwrap().0.is_some();
-            if !has_current {
-                self.next_action(actor);
-            }
-        }
-    }
-
-    fn stop_action(&mut self, actor: Entity) {
-        // Stop current action
-        let current = self.get_mut::<CurrentAction>(actor).unwrap().0.take();
-        if let Some((mut action, cfg)) = current {
-            action.stop(actor, self);
-            let mut actions = self.get_mut::<ActionQueue>(actor).unwrap();
-            // Push stopped action to front so it runs again when next command is called
-            actions.0.push_front((action, cfg));
-        }
-    }
-
-    fn next_action(&mut self, actor: Entity) {
-        // Remove current action
-        let current = self.get_mut::<CurrentAction>(actor).unwrap().0.take();
-        if let Some((mut action, cfg)) = current {
-            action.remove(actor, self);
-            if cfg.repeat {
-                // Add action to back of queue again if repeat
-                let mut actions = self.get_mut::<ActionQueue>(actor).unwrap();
-                actions.0.push_back((action, cfg));
-            }
-        }
-
-        // Get next action
-        let next = self.get_mut::<ActionQueue>(actor).unwrap().0.pop_front();
-
-        // Set next action
-        let mut commands = ActionCommands::default();
-        if let Some((mut action, cfg)) = next {
-            action.add(actor, self, &mut commands);
-            if let Some(mut current) = self.get_mut::<CurrentAction>(actor) {
-                current.0 = Some((action, cfg));
-            }
-        }
-
-        commands.apply(self);
-    }
-
-    fn clear_actions(&mut self, actor: Entity) {
-        // Remove current
-        let current = self.get_mut::<CurrentAction>(actor).unwrap().0.take();
-        if let Some((mut action, _)) = current {
-            action.remove(actor, self);
-        }
-
-        // Clear remaining
-        let mut actions = self.get_mut::<ActionQueue>(actor).unwrap();
-        actions.0.clear();
-    }
-
-    fn action_builder(&mut self, actor: Entity, config: AddConfig) -> ActionBuilderWorld {
-        ActionBuilderWorld {
-            actor,
-            config,
-            actions: Vec::default(),
+impl EntityWorldActionsExt for World {
+    fn action(&mut self, entity: Entity) -> EntityWorldActions {
+        EntityWorldActions {
+            entity,
+            config: AddConfig::default(),
+            actions: Vec::new(),
             world: self,
         }
     }
 }
 
-/// [`Action`] builder struct for [`World`].
-pub struct ActionBuilderWorld<'w> {
-    actor: Entity,
+pub struct EntityWorldActions<'a> {
+    entity: Entity,
     config: AddConfig,
-    actions: Vec<Box<dyn Action>>,
-    world: &'w mut World,
+    actions: Vec<(Box<dyn Action>, AddConfig)>,
+    world: &'a mut World,
 }
 
-impl<'w> ActionBuilderWorld<'w> {
-    /// Push an [`Action`] to the builder list.
-    /// No [`Action`] will be applied until [`ActionBuilderWorld::apply`] is called.
-    pub fn push(mut self, action: impl IntoAction) -> Self {
-        self.actions.push(action.into_boxed());
+impl ActionsExt for EntityWorldActions<'_> {
+    fn config(mut self, config: AddConfig) -> Self {
+        self.config = config;
         self
     }
 
-    /// Reverse the order for the currently pushed actions.
-    pub fn reverse(mut self) -> Self {
+    fn add(self, action: impl IntoAction) -> Self {
+        // Enqueue action
+        let action_tuple = (action.into_boxed(), self.config.into());
+        let mut actions = self.world.get_mut::<ActionQueue>(self.entity).unwrap();
+        match self.config.order {
+            AddOrder::Front => actions.0.push_front(action_tuple),
+            AddOrder::Back => actions.0.push_back(action_tuple),
+        }
+
+        // Start next action if nothing is currently running
+        if self.config.start {
+            let has_current = self
+                .world
+                .get::<CurrentAction>(self.entity)
+                .unwrap()
+                .0
+                .is_some();
+
+            if !has_current {
+                return self.next();
+            }
+        }
+
+        self
+    }
+
+    fn next(self) -> Self {
+        // Get current action
+        let current = self
+            .world
+            .get_mut::<CurrentAction>(self.entity)
+            .unwrap()
+            .0
+            .take();
+
+        // Remove current action
+        if let Some((mut action, cfg)) = current {
+            action.remove(self.entity, self.world);
+            if cfg.repeat {
+                // Add action to back of queue again if repeat
+                let mut actions = self.world.get_mut::<ActionQueue>(self.entity).unwrap();
+                actions.0.push_back((action, cfg));
+            }
+        }
+
+        // Get next action
+        let next = self
+            .world
+            .get_mut::<ActionQueue>(self.entity)
+            .unwrap()
+            .0
+            .pop_front();
+
+        // Set next action
+        let mut commands = ActionCommands::default();
+        if let Some((mut action, cfg)) = next {
+            action.add(self.entity, self.world, &mut commands);
+            if let Some(mut current) = self.world.get_mut::<CurrentAction>(self.entity) {
+                current.0 = Some((action, cfg));
+            }
+        }
+
+        commands.apply(self.world);
+
+        self
+    }
+
+    fn stop(self) -> Self {
+        // Get current action
+        let current = self
+            .world
+            .get_mut::<CurrentAction>(self.entity)
+            .unwrap()
+            .0
+            .take();
+
+        // Remove current action
+        if let Some((mut action, cfg)) = current {
+            action.stop(self.entity, self.world);
+            let mut actions = self.world.get_mut::<ActionQueue>(self.entity).unwrap();
+            // Push stopped action to front so it runs again when next action is called
+            actions.0.push_front((action, cfg));
+        }
+
+        self
+    }
+
+    fn clear(self) -> Self {
+        // Get current action
+        let current = self
+            .world
+            .get_mut::<CurrentAction>(self.entity)
+            .unwrap()
+            .0
+            .take();
+
+        // Remove current action
+        if let Some((mut action, _)) = current {
+            action.remove(self.entity, self.world);
+        }
+
+        // Clear remaining
+        let mut actions = self.world.get_mut::<ActionQueue>(self.entity).unwrap();
+        actions.0.clear();
+
+        self
+    }
+
+    fn push(mut self, action: impl IntoAction) -> Self {
+        self.actions.push((action.into_boxed(), self.config));
+        self
+    }
+
+    fn reverse(mut self) -> Self {
         self.actions.reverse();
         self
     }
 
-    /// Apply the pushed actions.
-    pub fn apply(self) {
-        for action in self.actions {
-            self.world.add_action(self.actor, action, self.config);
+    fn submit(mut self) -> Self {
+        let mut command_queue = CommandQueue::default();
+        let mut commands = Commands::new(&mut command_queue, self.world);
+
+        for (action, config) in self.actions.drain(..) {
+            commands.action(self.entity).config(config).add(action);
         }
+
+        command_queue.apply(self.world);
+
+        self
     }
 }


### PR DESCRIPTION
Simplify the API by having a single method for access to modifying actions. Instead of polluting the `Commands` struct with methods such as `next_action(entity)`, `clear_actions(entity)` and so on, provide one method called `action(entity)` that returns a struct for modifying actions.

```rust
// Before
commands.add_action(entity, action, default_config);
commands
    .action_builder(entity, config_a)
    .push(action)
    .push(action)
    .submit();
commands
    .action_builder(entity, config_b)
    .push(action)
    .push(action)
    .reverse()
    .submit();
commands.clear_actions(entity);

// After
commands.action(entity)
    .add(action)
    .config(config_a)
    .add(action)
    .add(action)
    .config(config_b)
    .push(action)
    .push(action)
    .reverse()
    .submit()
    .clear();
```

Calling `.action(entity)` on either `Commands`, `ActionCommands` or `World` now returns a struct implementing the `ModifyActionsExt` trait.

Also rename `Action::add` to `Action::start`.