### PR TITLE
Add `ActionBuilder` trait

### DIFF
--- a/src/action_commands.rs
+++ b/src/action_commands.rs
@@ -88,6 +88,7 @@ impl<'a> ModifyActions for EntityActions<'a> {
     }
 }
 
+/// Build a list of [`actions`](Action) using [`ActionCommands`].
 pub struct ActionsBuilder<'a> {
     entity: Entity,
     config: AddConfig,

--- a/src/action_commands.rs
+++ b/src/action_commands.rs
@@ -80,20 +80,18 @@ impl<'a> ModifyActions for EntityActions<'a> {
 
     fn builder(self) -> Self::Builder {
         ActionsBuilder {
-            entity: self.entity,
-            config: self.config,
+            config: AddConfig::default(),
             actions: Vec::new(),
-            commands: self.commands,
+            modifier: self,
         }
     }
 }
 
 /// Build a list of [`actions`](Action) using [`ActionCommands`].
 pub struct ActionsBuilder<'a> {
-    entity: Entity,
     config: AddConfig,
     actions: Vec<(Box<dyn Action>, AddConfig)>,
-    commands: &'a mut ActionCommands,
+    modifier: EntityActions<'a>,
 }
 
 impl<'a> ActionBuilder for ActionsBuilder<'a> {
@@ -116,16 +114,13 @@ impl<'a> ActionBuilder for ActionsBuilder<'a> {
 
     fn submit(self) -> Self::Modifier {
         for (action, config) in self.actions {
-            self.commands
+            self.modifier
+                .commands
                 .0
-                .push(ActionCommand::Add(self.entity, config, action));
+                .push(ActionCommand::Add(self.modifier.entity, config, action));
         }
 
-        EntityActions {
-            entity: self.entity,
-            config: self.config,
-            commands: self.commands,
-        }
+        self.modifier
     }
 }
 

--- a/src/action_commands.rs
+++ b/src/action_commands.rs
@@ -36,7 +36,9 @@ enum ActionCommand {
     Clear(Entity),
 }
 
-impl ModifyActions for EntityActions<'_> {
+impl<'a> ModifyActions for EntityActions<'a> {
+    type Builder = ActionsBuilder<'a>;
+
     fn config(mut self, config: AddConfig) -> Self {
         self.config = config;
         self
@@ -96,6 +98,15 @@ impl ModifyActions for EntityActions<'_> {
         }
         self
     }
+
+    fn builder(self) -> Self::Builder {
+        ActionsBuilder {
+            entity: self.entity,
+            config: self.config,
+            actions: Vec::new(), // TODO: remove
+            commands: self.commands,
+        }
+    }
 }
 
 impl ActionCommands {
@@ -121,6 +132,26 @@ impl ActionCommands {
                     world.actions(entity).clear();
                 }
             }
+        }
+    }
+}
+
+pub struct ActionsBuilder<'a> {
+    entity: Entity,
+    config: AddConfig,
+    actions: Vec<(Box<dyn Action>, AddConfig)>,
+    commands: &'a mut ActionCommands,
+}
+
+impl<'a> ActionBuilder for ActionsBuilder<'a> {
+    type Modifier = EntityActions<'a>;
+
+    fn submit(self) -> Self::Modifier {
+        EntityActions {
+            entity: self.entity,
+            config: self.config,
+            actions: Vec::new(), // TODO: remove
+            commands: self.commands,
         }
     }
 }

--- a/src/action_commands.rs
+++ b/src/action_commands.rs
@@ -92,15 +92,20 @@ impl<'a> ModifyActions for EntityActions<'a> {
 pub struct ActionsBuilder<'a> {
     entity: Entity,
     config: AddConfig,
-    actions: Vec<Box<dyn Action>>,
+    actions: Vec<(Box<dyn Action>, AddConfig)>,
     commands: &'a mut ActionCommands,
 }
 
 impl<'a> ActionBuilder for ActionsBuilder<'a> {
     type Modifier = EntityActions<'a>;
 
+    fn config(mut self, config: AddConfig) -> Self {
+        self.config = config;
+        self
+    }
+
     fn push(mut self, action: impl IntoAction) -> Self {
-        self.actions.push(action.into_boxed());
+        self.actions.push((action.into_boxed(), self.config));
         self
     }
 
@@ -110,10 +115,10 @@ impl<'a> ActionBuilder for ActionsBuilder<'a> {
     }
 
     fn submit(self) -> Self::Modifier {
-        for action in self.actions {
+        for (action, config) in self.actions {
             self.commands
                 .0
-                .push(ActionCommand::Add(self.entity, self.config, action));
+                .push(ActionCommand::Add(self.entity, config, action));
         }
 
         EntityActions {

--- a/src/action_commands.rs
+++ b/src/action_commands.rs
@@ -87,7 +87,7 @@ impl<'a> ModifyActions for EntityActions<'a> {
     }
 }
 
-/// Build a list of [`actions`](Action) using [`ActionCommands`].
+/// Build a list of actions using [`ActionCommands`].
 pub struct ActionsBuilder<'a> {
     config: AddConfig,
     actions: Vec<(Box<dyn Action>, AddConfig)>,

--- a/src/action_commands.rs
+++ b/src/action_commands.rs
@@ -146,7 +146,23 @@ pub struct ActionsBuilder<'a> {
 impl<'a> ActionBuilder for ActionsBuilder<'a> {
     type Modifier = EntityActions<'a>;
 
+    fn push(mut self, action: impl IntoAction) -> Self {
+        self.actions.push((action.into_boxed(), self.config));
+        self
+    }
+
+    fn reverse(mut self) -> Self {
+        self.actions.reverse();
+        self
+    }
+
     fn submit(self) -> Self::Modifier {
+        for (action, config) in self.actions {
+            self.commands
+                .0
+                .push(ActionCommand::Add(self.entity, action, config));
+        }
+
         EntityActions {
             entity: self.entity,
             config: self.config,

--- a/src/commands.rs
+++ b/src/commands.rs
@@ -91,3 +91,29 @@ impl<'w, 's> ModifyActions for EntityCommandsActions<'w, 's, '_> {
         self
     }
 }
+
+trait Builder {
+    type Modifier: ModifyActions;
+
+    fn submit(self) -> Self::Modifier;
+}
+
+pub struct CommandsActionsBuilder<'w, 's, 'a> {
+    entity: Entity,
+    config: AddConfig,
+    actions: Vec<(Box<dyn Action>, AddConfig)>,
+    commands: &'a mut Commands<'w, 's>,
+}
+
+impl<'w, 's, 'a> Builder for CommandsActionsBuilder<'w, 's, 'a> {
+    type Modifier = EntityCommandsActions<'a, 's, 'a>;
+
+    fn submit(self) -> Self::Modifier {
+        EntityCommandsActions {
+            entity: todo!(),
+            config: todo!(),
+            actions: todo!(),
+            commands: todo!(),
+        }
+    }
+}

--- a/src/commands.rs
+++ b/src/commands.rs
@@ -23,7 +23,9 @@ pub struct EntityCommandsActions<'w, 's, 'a> {
     commands: &'a mut Commands<'w, 's>,
 }
 
-impl<'w, 's> ModifyActions for EntityCommandsActions<'w, 's, '_> {
+impl<'w, 's, 'a> ModifyActions for EntityCommandsActions<'w, 's, 'a> {
+    type Builder = CommandsActionBuilder<'w, 's, 'a>;
+
     fn config(mut self, config: AddConfig) -> Self {
         self.config = config;
         self
@@ -89,6 +91,44 @@ impl<'w, 's> ModifyActions for EntityCommandsActions<'w, 's, '_> {
             });
         }
         self
+    }
+
+    // fn builder<'a>(&'a mut self) -> Self::Builder {
+    //     CommandsActionBuilder {
+    //         entity: self.entity,
+    //         config: self.config,
+    //         actions: Vec::new(), // TODO: remove
+    //         commands: self.commands,
+    //     }
+    // }
+
+    fn builder(self) -> Self::Builder {
+        CommandsActionBuilder {
+            entity: self.entity,
+            config: self.config,
+            actions: Vec::new(), // TODO: remove
+            commands: self.commands,
+        }
+    }
+}
+
+pub struct CommandsActionBuilder<'w, 's, 'a> {
+    entity: Entity,
+    config: AddConfig,
+    actions: Vec<(Box<dyn Action>, AddConfig)>,
+    commands: &'a mut Commands<'w, 's>,
+}
+
+impl<'w, 's, 'a> ActionBuilder for CommandsActionBuilder<'w, 's, 'a> {
+    type Modifier = EntityCommandsActions<'w, 's, 'a>;
+
+    fn submit(self) -> Self::Modifier {
+        EntityCommandsActions {
+            entity: self.entity,
+            config: self.config,
+            actions: Vec::new(), // TODO: remove
+            commands: self.commands,
+        }
     }
 }
 

--- a/src/commands.rs
+++ b/src/commands.rs
@@ -9,7 +9,6 @@ impl<'w: 'a, 's: 'a, 'a> ActionsProxy<'a> for Commands<'w, 's> {
         EntityCommandsActions {
             entity,
             config: AddConfig::default(),
-            actions: Vec::new(),
             commands: self,
         }
     }
@@ -19,7 +18,6 @@ impl<'w: 'a, 's: 'a, 'a> ActionsProxy<'a> for Commands<'w, 's> {
 pub struct EntityCommandsActions<'w, 's, 'a> {
     entity: Entity,
     config: AddConfig,
-    actions: Vec<(Box<dyn Action>, AddConfig)>,
     commands: &'a mut Commands<'w, 's>,
 }
 
@@ -74,30 +72,11 @@ impl<'w, 's, 'a> ModifyActions for EntityCommandsActions<'w, 's, 'a> {
         self
     }
 
-    fn push(mut self, action: impl IntoAction) -> Self {
-        self.actions.push((action.into_boxed(), self.config));
-        self
-    }
-
-    fn reverse(mut self) -> Self {
-        self.actions.reverse();
-        self
-    }
-
-    fn submit(mut self) -> Self {
-        for (action, config) in self.actions.drain(..) {
-            self.commands.add(move |world: &mut World| {
-                world.actions(self.entity).config(config).add(action);
-            });
-        }
-        self
-    }
-
     fn builder(self) -> Self::Builder {
         CommandsActionBuilder {
             entity: self.entity,
             config: self.config,
-            actions: Vec::new(), // TODO: remove
+            actions: Vec::new(),
             commands: self.commands,
         }
     }
@@ -133,7 +112,6 @@ impl<'w, 's, 'a> ActionBuilder for CommandsActionBuilder<'w, 's, 'a> {
         EntityCommandsActions {
             entity: self.entity,
             config: self.config,
-            actions: Vec::new(), // TODO: remove
             commands: self.commands,
         }
     }

--- a/src/commands.rs
+++ b/src/commands.rs
@@ -122,7 +122,23 @@ pub struct CommandsActionBuilder<'w, 's, 'a> {
 impl<'w, 's, 'a> ActionBuilder for CommandsActionBuilder<'w, 's, 'a> {
     type Modifier = EntityCommandsActions<'w, 's, 'a>;
 
+    fn push(mut self, action: impl IntoAction) -> Self {
+        self.actions.push((action.into_boxed(), self.config));
+        self
+    }
+
+    fn reverse(mut self) -> Self {
+        self.actions.reverse();
+        self
+    }
+
     fn submit(self) -> Self::Modifier {
+        for (action, config) in self.actions {
+            self.commands.add(move |world: &mut World| {
+                world.actions(self.entity).config(config).add(action);
+            });
+        }
+
         EntityCommandsActions {
             entity: self.entity,
             config: self.config,

--- a/src/commands.rs
+++ b/src/commands.rs
@@ -92,28 +92,28 @@ impl<'w, 's> ModifyActions for EntityCommandsActions<'w, 's, '_> {
     }
 }
 
-trait Builder {
-    type Modifier: ModifyActions;
+// trait Builder {
+//     type Modifier: ModifyActions;
 
-    fn submit(self) -> Self::Modifier;
-}
+//     fn submit(self) -> Self::Modifier;
+// }
 
-pub struct CommandsActionsBuilder<'w, 's, 'a> {
-    entity: Entity,
-    config: AddConfig,
-    actions: Vec<(Box<dyn Action>, AddConfig)>,
-    commands: &'a mut Commands<'w, 's>,
-}
+// pub struct CommandsActionsBuilder<'w, 's, 'a> {
+//     entity: Entity,
+//     config: AddConfig,
+//     actions: Vec<(Box<dyn Action>, AddConfig)>,
+//     commands: &'a mut Commands<'w, 's>,
+// }
 
-impl<'w, 's, 'a> Builder for CommandsActionsBuilder<'w, 's, 'a> {
-    type Modifier = EntityCommandsActions<'a, 's, 'a>;
+// impl<'w, 's, 'a> Builder for CommandsActionsBuilder<'w, 's, 'a> {
+//     type Modifier = EntityCommandsActions<'a, 's, 'a>;
 
-    fn submit(self) -> Self::Modifier {
-        EntityCommandsActions {
-            entity: todo!(),
-            config: todo!(),
-            actions: todo!(),
-            commands: todo!(),
-        }
-    }
-}
+//     fn submit(self) -> Self::Modifier {
+//         EntityCommandsActions {
+//             entity: todo!(),
+//             config: todo!(),
+//             actions: todo!(),
+//             commands: todo!(),
+//         }
+//     }
+// }

--- a/src/commands.rs
+++ b/src/commands.rs
@@ -93,15 +93,6 @@ impl<'w, 's, 'a> ModifyActions for EntityCommandsActions<'w, 's, 'a> {
         self
     }
 
-    // fn builder<'a>(&'a mut self) -> Self::Builder {
-    //     CommandsActionBuilder {
-    //         entity: self.entity,
-    //         config: self.config,
-    //         actions: Vec::new(), // TODO: remove
-    //         commands: self.commands,
-    //     }
-    // }
-
     fn builder(self) -> Self::Builder {
         CommandsActionBuilder {
             entity: self.entity,
@@ -147,29 +138,3 @@ impl<'w, 's, 'a> ActionBuilder for CommandsActionBuilder<'w, 's, 'a> {
         }
     }
 }
-
-// trait Builder {
-//     type Modifier: ModifyActions;
-
-//     fn submit(self) -> Self::Modifier;
-// }
-
-// pub struct CommandsActionsBuilder<'w, 's, 'a> {
-//     entity: Entity,
-//     config: AddConfig,
-//     actions: Vec<(Box<dyn Action>, AddConfig)>,
-//     commands: &'a mut Commands<'w, 's>,
-// }
-
-// impl<'w, 's, 'a> Builder for CommandsActionsBuilder<'w, 's, 'a> {
-//     type Modifier = EntityCommandsActions<'a, 's, 'a>;
-
-//     fn submit(self) -> Self::Modifier {
-//         EntityCommandsActions {
-//             entity: todo!(),
-//             config: todo!(),
-//             actions: todo!(),
-//             commands: todo!(),
-//         }
-//     }
-// }

--- a/src/commands.rs
+++ b/src/commands.rs
@@ -82,6 +82,7 @@ impl<'w, 's, 'a> ModifyActions for EntityCommandsActions<'w, 's, 'a> {
     }
 }
 
+/// Build a list of [`actions`](Action) using [`Commands`].
 pub struct CommandsActionBuilder<'w, 's, 'a> {
     entity: Entity,
     config: AddConfig,

--- a/src/commands.rs
+++ b/src/commands.rs
@@ -86,7 +86,7 @@ impl<'w, 's, 'a> ModifyActions for EntityCommandsActions<'w, 's, 'a> {
 pub struct CommandsActionBuilder<'w, 's, 'a> {
     entity: Entity,
     config: AddConfig,
-    actions: Vec<(Box<dyn Action>, AddConfig)>,
+    actions: Vec<Box<dyn Action>>,
     commands: &'a mut Commands<'w, 's>,
 }
 
@@ -94,7 +94,7 @@ impl<'w, 's, 'a> ActionBuilder for CommandsActionBuilder<'w, 's, 'a> {
     type Modifier = EntityCommandsActions<'w, 's, 'a>;
 
     fn push(mut self, action: impl IntoAction) -> Self {
-        self.actions.push((action.into_boxed(), self.config));
+        self.actions.push(action.into_boxed());
         self
     }
 
@@ -104,9 +104,9 @@ impl<'w, 's, 'a> ActionBuilder for CommandsActionBuilder<'w, 's, 'a> {
     }
 
     fn submit(self) -> Self::Modifier {
-        for (action, config) in self.actions {
+        for action in self.actions {
             self.commands.add(move |world: &mut World| {
-                world.actions(self.entity).config(config).add(action);
+                world.actions(self.entity).config(self.config).add(action);
             });
         }
 

--- a/src/commands.rs
+++ b/src/commands.rs
@@ -22,7 +22,7 @@ pub struct EntityCommandsActions<'w, 's, 'a> {
 }
 
 impl<'w, 's, 'a> ModifyActions for EntityCommandsActions<'w, 's, 'a> {
-    type Builder = CommandsActionBuilder<'w, 's, 'a>;
+    type Builder = ActionCommandsBuilder<'w, 's, 'a>;
 
     fn config(mut self, config: AddConfig) -> Self {
         self.config = config;
@@ -73,7 +73,7 @@ impl<'w, 's, 'a> ModifyActions for EntityCommandsActions<'w, 's, 'a> {
     }
 
     fn builder(self) -> Self::Builder {
-        CommandsActionBuilder {
+        ActionCommandsBuilder {
             entity: self.entity,
             config: self.config,
             actions: Vec::new(),
@@ -83,14 +83,14 @@ impl<'w, 's, 'a> ModifyActions for EntityCommandsActions<'w, 's, 'a> {
 }
 
 /// Build a list of [`actions`](Action) using [`Commands`].
-pub struct CommandsActionBuilder<'w, 's, 'a> {
+pub struct ActionCommandsBuilder<'w, 's, 'a> {
     entity: Entity,
     config: AddConfig,
     actions: Vec<(Box<dyn Action>, AddConfig)>,
     commands: &'a mut Commands<'w, 's>,
 }
 
-impl<'w, 's, 'a> ActionBuilder for CommandsActionBuilder<'w, 's, 'a> {
+impl<'w, 's, 'a> ActionBuilder for ActionCommandsBuilder<'w, 's, 'a> {
     type Modifier = EntityCommandsActions<'w, 's, 'a>;
 
     fn config(mut self, config: AddConfig) -> Self {

--- a/src/commands.rs
+++ b/src/commands.rs
@@ -74,20 +74,18 @@ impl<'w, 's, 'a> ModifyActions for EntityCommandsActions<'w, 's, 'a> {
 
     fn builder(self) -> Self::Builder {
         ActionCommandsBuilder {
-            entity: self.entity,
-            config: self.config,
+            config: AddConfig::default(),
             actions: Vec::new(),
-            commands: self.commands,
+            modifier: self,
         }
     }
 }
 
 /// Build a list of [`actions`](Action) using [`Commands`].
 pub struct ActionCommandsBuilder<'w, 's, 'a> {
-    entity: Entity,
     config: AddConfig,
     actions: Vec<(Box<dyn Action>, AddConfig)>,
-    commands: &'a mut Commands<'w, 's>,
+    modifier: EntityCommandsActions<'w, 's, 'a>,
 }
 
 impl<'w, 's, 'a> ActionBuilder for ActionCommandsBuilder<'w, 's, 'a> {
@@ -110,15 +108,14 @@ impl<'w, 's, 'a> ActionBuilder for ActionCommandsBuilder<'w, 's, 'a> {
 
     fn submit(self) -> Self::Modifier {
         for (action, config) in self.actions {
-            self.commands.add(move |world: &mut World| {
-                world.actions(self.entity).config(config).add(action);
+            self.modifier.commands.add(move |world: &mut World| {
+                world
+                    .actions(self.modifier.entity)
+                    .config(config)
+                    .add(action);
             });
         }
 
-        EntityCommandsActions {
-            entity: self.entity,
-            config: self.config,
-            commands: self.commands,
-        }
+        self.modifier
     }
 }

--- a/src/commands.rs
+++ b/src/commands.rs
@@ -81,7 +81,7 @@ impl<'w, 's, 'a> ModifyActions for EntityCommandsActions<'w, 's, 'a> {
     }
 }
 
-/// Build a list of [`actions`](Action) using [`Commands`].
+/// Build a list of actions using [`Commands`].
 pub struct ActionCommandsBuilder<'w, 's, 'a> {
     config: AddConfig,
     actions: Vec<(Box<dyn Action>, AddConfig)>,

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -101,7 +101,7 @@ impl Default for AddConfig {
     }
 }
 
-/// The reason why an [Action] was stopped.
+/// The reason why an [`Action`] was stopped.
 #[derive(Clone, Copy)]
 pub enum StopReason {
     /// The [`action`](Action) was finished.

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -64,7 +64,7 @@ pub use commands::*;
 pub use traits::*;
 pub use world::*;
 
-/// The component bundle that all entities with [`actions`](Action) must have.
+/// The component bundle that all entities with actions must have.
 #[derive(Default, Bundle)]
 pub struct ActionsBundle {
     queue: ActionQueue,

--- a/src/tests.rs
+++ b/src/tests.rs
@@ -251,6 +251,7 @@ fn push() {
     let e = ecs.spawn_action_entity();
 
     ecs.actions(e)
+        .builder()
         .push(EmptyAction)
         .push(EmptyAction)
         .push(EmptyAction);
@@ -259,6 +260,7 @@ fn push() {
     assert!(ecs.get_action_queue(e).len() == 0);
 
     ecs.actions(e)
+        .builder()
         .push(EmptyAction)
         .push(EmptyAction)
         .push(EmptyAction)
@@ -268,6 +270,7 @@ fn push() {
     assert!(ecs.get_action_queue(e).len() == 0);
 
     ecs.actions(e)
+        .builder()
         .push(CountdownAction::new(0))
         .push(CountdownAction::new(0))
         .push(CountdownAction::new(0))
@@ -372,6 +375,7 @@ fn order() {
             start: false,
             repeat: false,
         })
+        .builder()
         .push(Order::<A>::default())
         .push(Order::<B>::default())
         .push(Order::<C>::default())
@@ -396,6 +400,7 @@ fn order() {
             start: false,
             repeat: false,
         })
+        .builder()
         .push(Order::<A>::default())
         .push(Order::<B>::default())
         .push(Order::<C>::default())

--- a/src/tests.rs
+++ b/src/tests.rs
@@ -300,6 +300,11 @@ fn repeat() {
 
     assert!(ecs.get_current_action(e).is_some());
     assert!(ecs.get_action_queue(e).len() == 0);
+
+    ecs.run();
+
+    assert!(ecs.get_current_action(e).is_some());
+    assert!(ecs.get_action_queue(e).len() == 0);
 }
 
 #[test]
@@ -445,6 +450,7 @@ fn pause_resume() {
 
     ecs.run();
     ecs.run();
+    ecs.run();
 
-    assert!(get_first_countdown_value(&mut ecs.world) == 99);
+    assert!(get_first_countdown_value(&mut ecs.world) == 98);
 }

--- a/src/tests.rs
+++ b/src/tests.rs
@@ -370,12 +370,12 @@ fn order() {
     // C, B, A
     ecs.actions(e)
         .clear()
+        .builder()
         .config(AddConfig {
             order: AddOrder::Front,
             start: false,
             repeat: false,
         })
-        .builder()
         .push(Order::<A>::default())
         .push(Order::<B>::default())
         .push(Order::<C>::default())
@@ -395,12 +395,12 @@ fn order() {
     // A, B, C
     ecs.actions(e)
         .clear()
+        .builder()
         .config(AddConfig {
             order: AddOrder::Front,
             start: false,
             repeat: false,
         })
-        .builder()
         .push(Order::<A>::default())
         .push(Order::<B>::default())
         .push(Order::<C>::default())

--- a/src/traits.rs
+++ b/src/traits.rs
@@ -136,6 +136,38 @@ pub trait ActionsProxy<'a> {
     fn actions(&'a mut self, entity: Entity) -> Self::Modifier;
 }
 
+trait Modify {
+    type Builder: Builder;
+
+    fn builder(self) -> Self::Builder;
+}
+
+trait Builder {
+    type Modifier: Modify;
+
+    fn submit(self) -> Self::Modifier;
+}
+
+struct MyModifier;
+
+impl Modify for MyModifier {
+    type Builder = MyBuilder;
+
+    fn builder(self) -> Self::Builder {
+        todo!()
+    }
+}
+
+struct MyBuilder;
+
+impl Builder for MyBuilder {
+    type Modifier = MyModifier;
+
+    fn submit(self) -> Self::Modifier {
+        todo!()
+    }
+}
+
 /// Methods for modifying actions.
 pub trait ModifyActions {
     /// Sets the current [`config`](AddConfig) for actions to be added.

--- a/src/traits.rs
+++ b/src/traits.rs
@@ -148,7 +148,7 @@ trait Builder {
     fn submit(self) -> Self::Modifier;
 }
 
-pub struct MyModifier<'w, 's, 'a> {
+struct MyModifier<'w, 's, 'a> {
     entity: Entity,
     config: AddConfig,
     commands: &'a mut Commands<'w, 's>,
@@ -158,7 +158,11 @@ impl<'w: 'a, 's: 'a, 'a> Modify for MyModifier<'w, 's, 'a> {
     type Builder = MyBuilder<'w, 's, 'a>;
 
     fn builder(self) -> Self::Builder {
-        todo!()
+        MyBuilder {
+            entity: self.entity,
+            config: self.config,
+            commands: self.commands,
+        }
     }
 }
 
@@ -172,7 +176,11 @@ impl<'w, 's, 'a> Builder for MyBuilder<'w, 's, 'a> {
     type Modifier = MyModifier<'w, 's, 'a>;
 
     fn submit(self) -> Self::Modifier {
-        todo!()
+        MyModifier {
+            entity: self.entity,
+            config: self.config,
+            commands: self.commands,
+        }
     }
 }
 

--- a/src/traits.rs
+++ b/src/traits.rs
@@ -227,4 +227,7 @@ pub trait ModifyActions {
 
     /// Submits the [`pushed`](Self::push) actions by draining the list and adding them to the queue.
     fn submit(self) -> Self;
+
+    // fn builder<'a>(&'a mut self) -> Self::Builder;
+    fn builder(self) -> Self::Builder;
 }

--- a/src/traits.rs
+++ b/src/traits.rs
@@ -136,62 +136,6 @@ pub trait ActionsProxy<'a> {
     fn actions(&'a mut self, entity: Entity) -> Self::Modifier;
 }
 
-pub trait ActionBuilder {
-    type Modifier: ModifyActions;
-
-    fn push(self, action: impl IntoAction) -> Self;
-    fn reverse(self) -> Self;
-    fn submit(self) -> Self::Modifier;
-}
-
-// trait Modify {
-//     type Builder: Builder;
-
-//     fn builder(self) -> Self::Builder;
-// }
-
-// trait Builder {
-//     type Modifier: Modify;
-
-//     fn submit(self) -> Self::Modifier;
-// }
-
-// struct MyModifier<'w, 's, 'a> {
-//     entity: Entity,
-//     config: AddConfig,
-//     commands: &'a mut Commands<'w, 's>,
-// }
-
-// impl<'w: 'a, 's: 'a, 'a> Modify for MyModifier<'w, 's, 'a> {
-//     type Builder = MyBuilder<'w, 's, 'a>;
-
-//     fn builder(self) -> Self::Builder {
-//         MyBuilder {
-//             entity: self.entity,
-//             config: self.config,
-//             commands: self.commands,
-//         }
-//     }
-// }
-
-// struct MyBuilder<'w, 's, 'a> {
-//     entity: Entity,
-//     config: AddConfig,
-//     commands: &'a mut Commands<'w, 's>,
-// }
-
-// impl<'w, 's, 'a> Builder for MyBuilder<'w, 's, 'a> {
-//     type Modifier = MyModifier<'w, 's, 'a>;
-
-//     fn submit(self) -> Self::Modifier {
-//         MyModifier {
-//             entity: self.entity,
-//             config: self.config,
-//             commands: self.commands,
-//         }
-//     }
-// }
-
 /// Methods for modifying actions.
 pub trait ModifyActions {
     type Builder: ActionBuilder;
@@ -230,6 +174,13 @@ pub trait ModifyActions {
     /// Submits the [`pushed`](Self::push) actions by draining the list and adding them to the queue.
     fn submit(self) -> Self;
 
-    // fn builder<'a>(&'a mut self) -> Self::Builder;
     fn builder(self) -> Self::Builder;
+}
+
+pub trait ActionBuilder {
+    type Modifier: ModifyActions;
+
+    fn push(self, action: impl IntoAction) -> Self;
+    fn reverse(self) -> Self;
+    fn submit(self) -> Self::Modifier;
 }

--- a/src/traits.rs
+++ b/src/traits.rs
@@ -129,19 +129,19 @@ impl IntoAction for Box<dyn Action> {
 /// }
 ///```
 pub trait ActionsProxy<'a> {
-    /// The type returned for modifying [`actions`](Action).
+    /// The type returned for modifying actions.
     type Modifier: ModifyActions;
 
     /// Returns [`Self::Modifier`] for specified [`Entity`].
     fn actions(&'a mut self, entity: Entity) -> Self::Modifier;
 }
 
-/// Methods for modifying [`actions`](Action).
+/// Methods for modifying actions.
 pub trait ModifyActions {
-    /// The type returned for building a list of [`actions`](Action).
+    /// The type returned for building a list of actions.
     type Builder: ActionBuilder;
 
-    /// Sets the current [`config`](AddConfig) for [`actions`](Action) to be added.
+    /// Sets the current [`config`](AddConfig) for actions to be added.
     fn config(self, config: AddConfig) -> Self;
 
     /// Adds an [`action`](Action) to the queue with the current [`config`](AddConfig).
@@ -165,16 +165,16 @@ pub trait ModifyActions {
     /// Current [`action`](Action) is [`stopped`](Action::on_stop) as [`canceled`](StopReason::Canceled).
     fn clear(self) -> Self;
 
-    /// Build a list of [`actions`](Action).
+    /// Build a list of actions.
     fn builder(self) -> Self::Builder;
 }
 
-/// Methods for building a list of [`actions`](Action).
+/// Methods for building a list of actions.
 pub trait ActionBuilder {
     /// The type that is returned after [`submit`](Self::submit) is called.
     type Modifier: ModifyActions;
 
-    /// Sets the current [`config`](AddConfig) for [`actions`](Action) to be pushed.
+    /// Sets the current [`config`](AddConfig) for actions to be pushed.
     fn config(self, config: AddConfig) -> Self;
 
     /// Pushes an [`action`](Action) to a list with the current [`config`](AddConfig).

--- a/src/traits.rs
+++ b/src/traits.rs
@@ -136,56 +136,64 @@ pub trait ActionsProxy<'a> {
     fn actions(&'a mut self, entity: Entity) -> Self::Modifier;
 }
 
-trait Modify {
-    type Builder: Builder;
-
-    fn builder(self) -> Self::Builder;
-}
-
-trait Builder {
-    type Modifier: Modify;
+pub trait ActionBuilder {
+    type Modifier: ModifyActions;
 
     fn submit(self) -> Self::Modifier;
 }
 
-struct MyModifier<'w, 's, 'a> {
-    entity: Entity,
-    config: AddConfig,
-    commands: &'a mut Commands<'w, 's>,
-}
+// trait Modify {
+//     type Builder: Builder;
 
-impl<'w: 'a, 's: 'a, 'a> Modify for MyModifier<'w, 's, 'a> {
-    type Builder = MyBuilder<'w, 's, 'a>;
+//     fn builder(self) -> Self::Builder;
+// }
 
-    fn builder(self) -> Self::Builder {
-        MyBuilder {
-            entity: self.entity,
-            config: self.config,
-            commands: self.commands,
-        }
-    }
-}
+// trait Builder {
+//     type Modifier: Modify;
 
-struct MyBuilder<'w, 's, 'a> {
-    entity: Entity,
-    config: AddConfig,
-    commands: &'a mut Commands<'w, 's>,
-}
+//     fn submit(self) -> Self::Modifier;
+// }
 
-impl<'w, 's, 'a> Builder for MyBuilder<'w, 's, 'a> {
-    type Modifier = MyModifier<'w, 's, 'a>;
+// struct MyModifier<'w, 's, 'a> {
+//     entity: Entity,
+//     config: AddConfig,
+//     commands: &'a mut Commands<'w, 's>,
+// }
 
-    fn submit(self) -> Self::Modifier {
-        MyModifier {
-            entity: self.entity,
-            config: self.config,
-            commands: self.commands,
-        }
-    }
-}
+// impl<'w: 'a, 's: 'a, 'a> Modify for MyModifier<'w, 's, 'a> {
+//     type Builder = MyBuilder<'w, 's, 'a>;
+
+//     fn builder(self) -> Self::Builder {
+//         MyBuilder {
+//             entity: self.entity,
+//             config: self.config,
+//             commands: self.commands,
+//         }
+//     }
+// }
+
+// struct MyBuilder<'w, 's, 'a> {
+//     entity: Entity,
+//     config: AddConfig,
+//     commands: &'a mut Commands<'w, 's>,
+// }
+
+// impl<'w, 's, 'a> Builder for MyBuilder<'w, 's, 'a> {
+//     type Modifier = MyModifier<'w, 's, 'a>;
+
+//     fn submit(self) -> Self::Modifier {
+//         MyModifier {
+//             entity: self.entity,
+//             config: self.config,
+//             commands: self.commands,
+//         }
+//     }
+// }
 
 /// Methods for modifying actions.
 pub trait ModifyActions {
+    type Builder: ActionBuilder;
+
     /// Sets the current [`config`](AddConfig) for actions to be added.
     fn config(self, config: AddConfig) -> Self;
 

--- a/src/traits.rs
+++ b/src/traits.rs
@@ -174,6 +174,9 @@ pub trait ActionBuilder {
     /// The type that is returned after [`submit`](Self::submit) is called.
     type Modifier: ModifyActions;
 
+    /// Sets the current [`config`](AddConfig) for [`actions`](Action) to be pushed.
+    fn config(self, config: AddConfig) -> Self;
+
     /// Pushes an [`action`](Action) to a list with the current [`config`](AddConfig).
     /// Pushed actions will not be added to the queue until [`submit`](Self::submit) is called.
     fn push(self, action: impl IntoAction) -> Self;

--- a/src/traits.rs
+++ b/src/traits.rs
@@ -148,21 +148,21 @@ pub trait ModifyActions {
     fn add(self, action: impl IntoAction) -> Self;
 
     /// [`Starts`](Action::on_start) the next [`action`](Action) in the queue.
-    /// Current action is [`canceled`](StopReason::Canceled).
+    /// Current action is [`stopped`](Action::on_stop) as [`canceled`](StopReason::Canceled).
     fn next(self) -> Self;
 
     /// [`Starts`](Action::on_start) the next [`action`](Action) in the queue.
-    /// Current action is [`finished`](StopReason::Finished).
+    /// Current action is [`stopped`](Action::on_stop) as [`finished`](StopReason::Finished).
     fn finish(self) -> Self;
 
-    /// [`Pauses`](Action::on_start) the current [`action`](Action).
+    /// [`Stops`](Action::on_stop) the current [`action`](Action) as [`paused`](StopReason::Paused).
     fn pause(self) -> Self;
 
     /// [`Stops`](Action::on_stop) the current [`action`](Action) with specified [`reason`](StopReason).
     fn stop(self, reason: StopReason) -> Self;
 
     /// Clears the actions queue.
-    /// Current [`action`](Action) is [`canceled`](StopReason::Canceled).
+    /// Current [`action`](Action) is [`stopped`](Action::on_stop) as [`canceled`](StopReason::Canceled).
     fn clear(self) -> Self;
 
     /// Build a list of [`actions`](Action).

--- a/src/traits.rs
+++ b/src/traits.rs
@@ -148,20 +148,28 @@ trait Builder {
     fn submit(self) -> Self::Modifier;
 }
 
-struct MyModifier;
+pub struct MyModifier<'w, 's, 'a> {
+    entity: Entity,
+    config: AddConfig,
+    commands: &'a mut Commands<'w, 's>,
+}
 
-impl Modify for MyModifier {
-    type Builder = MyBuilder;
+impl<'w: 'a, 's: 'a, 'a> Modify for MyModifier<'w, 's, 'a> {
+    type Builder = MyBuilder<'w, 's, 'a>;
 
     fn builder(self) -> Self::Builder {
         todo!()
     }
 }
 
-struct MyBuilder;
+struct MyBuilder<'w, 's, 'a> {
+    entity: Entity,
+    config: AddConfig,
+    commands: &'a mut Commands<'w, 's>,
+}
 
-impl Builder for MyBuilder {
-    type Modifier = MyModifier;
+impl<'w, 's, 'a> Builder for MyBuilder<'w, 's, 'a> {
+    type Modifier = MyModifier<'w, 's, 'a>;
 
     fn submit(self) -> Self::Modifier {
         todo!()

--- a/src/traits.rs
+++ b/src/traits.rs
@@ -139,6 +139,8 @@ pub trait ActionsProxy<'a> {
 pub trait ActionBuilder {
     type Modifier: ModifyActions;
 
+    fn push(self, action: impl IntoAction) -> Self;
+    fn reverse(self) -> Self;
     fn submit(self) -> Self::Modifier;
 }
 

--- a/src/traits.rs
+++ b/src/traits.rs
@@ -164,6 +164,12 @@ pub trait ModifyActions {
     /// Current action is [`canceled`](StopReason::Canceled).
     fn clear(self) -> Self;
 
+    fn builder(self) -> Self::Builder;
+}
+
+pub trait ActionBuilder {
+    type Modifier: ModifyActions;
+
     /// Pushes an [`action`](Action) to a list with the current [`config`](AddConfig).
     /// Pushed actions __will not__ be added to the queue until [`submit`](Self::submit) is called.
     fn push(self, action: impl IntoAction) -> Self;
@@ -171,16 +177,6 @@ pub trait ModifyActions {
     /// Reverses the order of the [`pushed`](Self::push) actions.
     fn reverse(self) -> Self;
 
-    /// Submits the [`pushed`](Self::push) actions by draining the list and adding them to the queue.
-    fn submit(self) -> Self;
-
-    fn builder(self) -> Self::Builder;
-}
-
-pub trait ActionBuilder {
-    type Modifier: ModifyActions;
-
-    fn push(self, action: impl IntoAction) -> Self;
-    fn reverse(self) -> Self;
+    /// Submits the [`pushed`](Self::push) actions by consuming the list and adding them to the queue.
     fn submit(self) -> Self::Modifier;
 }

--- a/src/traits.rs
+++ b/src/traits.rs
@@ -129,49 +129,53 @@ impl IntoAction for Box<dyn Action> {
 /// }
 ///```
 pub trait ActionsProxy<'a> {
-    /// The type returned for modifying actions.
+    /// The type returned for modifying [`actions`](Action).
     type Modifier: ModifyActions;
 
     /// Returns [`Self::Modifier`] for specified [`Entity`].
     fn actions(&'a mut self, entity: Entity) -> Self::Modifier;
 }
 
-/// Methods for modifying actions.
+/// Methods for modifying [`actions`](Action).
 pub trait ModifyActions {
+    /// The type returned for building a list of [`actions`](Action).
     type Builder: ActionBuilder;
 
-    /// Sets the current [`config`](AddConfig) for actions to be added.
+    /// Sets the current [`config`](AddConfig) for [`actions`](Action) to be added.
     fn config(self, config: AddConfig) -> Self;
 
     /// Adds an [`action`](Action) to the queue with the current [`config`](AddConfig).
     fn add(self, action: impl IntoAction) -> Self;
 
-    /// [`Starts`](Action::on_start) the next action in the queue.
+    /// [`Starts`](Action::on_start) the next [`action`](Action) in the queue.
     /// Current action is [`canceled`](StopReason::Canceled).
     fn next(self) -> Self;
 
-    /// [`Starts`](Action::on_start) the next action in the queue.
+    /// [`Starts`](Action::on_start) the next [`action`](Action) in the queue.
     /// Current action is [`finished`](StopReason::Finished).
     fn finish(self) -> Self;
 
-    /// [`Pauses`](Action::on_start) the current action.
+    /// [`Pauses`](Action::on_start) the current [`action`](Action).
     fn pause(self) -> Self;
 
     /// [`Stops`](Action::on_stop) the current [`action`](Action) with specified [`reason`](StopReason).
     fn stop(self, reason: StopReason) -> Self;
 
     /// Clears the actions queue.
-    /// Current action is [`canceled`](StopReason::Canceled).
+    /// Current [`action`](Action) is [`canceled`](StopReason::Canceled).
     fn clear(self) -> Self;
 
+    /// Build a list of [`actions`](Action).
     fn builder(self) -> Self::Builder;
 }
 
+/// Methods for building a list of [`actions`](Action).
 pub trait ActionBuilder {
+    /// The type that is returned after [`submit`](Self::submit) is called.
     type Modifier: ModifyActions;
 
     /// Pushes an [`action`](Action) to a list with the current [`config`](AddConfig).
-    /// Pushed actions __will not__ be added to the queue until [`submit`](Self::submit) is called.
+    /// Pushed actions will not be added to the queue until [`submit`](Self::submit) is called.
     fn push(self, action: impl IntoAction) -> Self;
 
     /// Reverses the order of the [`pushed`](Self::push) actions.

--- a/src/world.rs
+++ b/src/world.rs
@@ -77,20 +77,18 @@ impl<'a> ModifyActions for EntityWorldActions<'a> {
 
     fn builder(self) -> Self::Builder {
         ActionWorldBuilder {
-            entity: self.entity,
-            config: self.config,
+            config: AddConfig::default(),
             actions: Vec::new(),
-            world: self.world,
+            modifier: self,
         }
     }
 }
 
 /// Build a list of [`actions`](Action) using [`World`].
 pub struct ActionWorldBuilder<'a> {
-    entity: Entity,
     config: AddConfig,
     actions: Vec<(Box<dyn Action>, AddConfig)>,
-    world: &'a mut World,
+    modifier: EntityWorldActions<'a>,
 }
 
 impl<'a> ActionBuilder for ActionWorldBuilder<'a> {
@@ -113,14 +111,14 @@ impl<'a> ActionBuilder for ActionWorldBuilder<'a> {
 
     fn submit(self) -> Self::Modifier {
         for (action, config) in self.actions {
-            self.world.actions(self.entity).config(config).add(action);
+            self.modifier
+                .world
+                .actions(self.modifier.entity)
+                .config(config)
+                .add(action);
         }
 
-        EntityWorldActions {
-            entity: self.entity,
-            config: self.config,
-            world: self.world,
-        }
+        self.modifier
     }
 }
 

--- a/src/world.rs
+++ b/src/world.rs
@@ -23,7 +23,9 @@ pub struct EntityWorldActions<'a> {
     world: &'a mut World,
 }
 
-impl ModifyActions for EntityWorldActions<'_> {
+impl<'a> ModifyActions for EntityWorldActions<'a> {
+    type Builder = WorldActionBuilder<'a>;
+
     fn config(mut self, config: AddConfig) -> Self {
         self.config = config;
 
@@ -104,6 +106,15 @@ impl ModifyActions for EntityWorldActions<'_> {
 
         self
     }
+
+    fn builder(self) -> Self::Builder {
+        WorldActionBuilder {
+            entity: self.entity,
+            config: self.config,
+            actions: Vec::new(), // TODO: remove
+            world: self.world,
+        }
+    }
 }
 
 impl EntityWorldActions<'_> {
@@ -158,5 +169,25 @@ impl EntityWorldActions<'_> {
             .get::<CurrentAction>(self.entity)
             .unwrap()
             .is_some()
+    }
+}
+
+pub struct WorldActionBuilder<'a> {
+    entity: Entity,
+    config: AddConfig,
+    actions: Vec<(Box<dyn Action>, AddConfig)>,
+    world: &'a mut World,
+}
+
+impl<'a> ActionBuilder for WorldActionBuilder<'a> {
+    type Modifier = EntityWorldActions<'a>;
+
+    fn submit(self) -> Self::Modifier {
+        EntityWorldActions {
+            entity: self.entity,
+            config: self.config,
+            actions: Vec::new(), // TODO: remove
+            world: self.world,
+        }
     }
 }

--- a/src/world.rs
+++ b/src/world.rs
@@ -84,7 +84,7 @@ impl<'a> ModifyActions for EntityWorldActions<'a> {
     }
 }
 
-/// Build a list of [`actions`](Action) using [`World`].
+/// Build a list of actions using [`World`].
 pub struct ActionWorldBuilder<'a> {
     config: AddConfig,
     actions: Vec<(Box<dyn Action>, AddConfig)>,

--- a/src/world.rs
+++ b/src/world.rs
@@ -22,7 +22,7 @@ pub struct EntityWorldActions<'a> {
 }
 
 impl<'a> ModifyActions for EntityWorldActions<'a> {
-    type Builder = WorldActionBuilder<'a>;
+    type Builder = ActionWorldBuilder<'a>;
 
     fn config(mut self, config: AddConfig) -> Self {
         self.config = config;
@@ -76,7 +76,7 @@ impl<'a> ModifyActions for EntityWorldActions<'a> {
     }
 
     fn builder(self) -> Self::Builder {
-        WorldActionBuilder {
+        ActionWorldBuilder {
             entity: self.entity,
             config: self.config,
             actions: Vec::new(),
@@ -86,14 +86,14 @@ impl<'a> ModifyActions for EntityWorldActions<'a> {
 }
 
 /// Build a list of [`actions`](Action) using [`World`].
-pub struct WorldActionBuilder<'a> {
+pub struct ActionWorldBuilder<'a> {
     entity: Entity,
     config: AddConfig,
     actions: Vec<(Box<dyn Action>, AddConfig)>,
     world: &'a mut World,
 }
 
-impl<'a> ActionBuilder for WorldActionBuilder<'a> {
+impl<'a> ActionBuilder for ActionWorldBuilder<'a> {
     type Modifier = EntityWorldActions<'a>;
 
     fn config(mut self, config: AddConfig) -> Self {

--- a/src/world.rs
+++ b/src/world.rs
@@ -1,4 +1,4 @@
-use bevy_ecs::{prelude::*, system::CommandQueue};
+use bevy_ecs::prelude::*;
 
 use crate::*;
 
@@ -26,7 +26,6 @@ impl<'a> ModifyActions for EntityWorldActions<'a> {
 
     fn config(mut self, config: AddConfig) -> Self {
         self.config = config;
-
         self
     }
 
@@ -48,26 +47,22 @@ impl<'a> ModifyActions for EntityWorldActions<'a> {
     fn next(mut self) -> Self {
         self.stop_current_action(StopReason::Canceled);
         self.start_next_action();
-
         self
     }
 
     fn finish(mut self) -> Self {
         self.stop_current_action(StopReason::Finished);
         self.start_next_action();
-
         self
     }
 
     fn pause(mut self) -> Self {
         self.stop_current_action(StopReason::Paused);
-
         self
     }
 
     fn stop(mut self, reason: StopReason) -> Self {
         self.stop_current_action(reason);
-
         self
     }
 
@@ -94,7 +89,7 @@ impl<'a> ModifyActions for EntityWorldActions<'a> {
 pub struct WorldActionBuilder<'a> {
     entity: Entity,
     config: AddConfig,
-    actions: Vec<(Box<dyn Action>, AddConfig)>,
+    actions: Vec<Box<dyn Action>>,
     world: &'a mut World,
 }
 
@@ -102,7 +97,7 @@ impl<'a> ActionBuilder for WorldActionBuilder<'a> {
     type Modifier = EntityWorldActions<'a>;
 
     fn push(mut self, action: impl IntoAction) -> Self {
-        self.actions.push((action.into_boxed(), self.config));
+        self.actions.push(action.into_boxed());
         self
     }
 
@@ -112,14 +107,12 @@ impl<'a> ActionBuilder for WorldActionBuilder<'a> {
     }
 
     fn submit(self) -> Self::Modifier {
-        let mut command_queue = CommandQueue::default();
-        let mut commands = Commands::new(&mut command_queue, self.world);
-
-        for (action, config) in self.actions {
-            commands.actions(self.entity).config(config).add(action);
+        for action in self.actions {
+            self.world
+                .actions(self.entity)
+                .config(self.config)
+                .add(action);
         }
-
-        command_queue.apply(self.world);
 
         EntityWorldActions {
             entity: self.entity,

--- a/src/world.rs
+++ b/src/world.rs
@@ -90,6 +90,7 @@ impl<'a> ModifyActions for EntityWorldActions<'a> {
     }
 }
 
+/// Build a list of [`actions`](Action) using [`World`].
 pub struct WorldActionBuilder<'a> {
     entity: Entity,
     config: AddConfig,


### PR DESCRIPTION
Make building a list of actions more explicit with the `ActionBuilder` trait. Start building a list by calling the `ModifyActions::builder` method, and submit with `ActionBuilder::submit` which returns the type for modifying actions again.

```rust
commands.actions(entity)
    // Modify actions as normal
    .add(action)
    // Make a list of actions
    .builder()
    .config(AddConfig {
        order: AddOrder::Front,
        start: false,
        repeat: false,
    })
    .push(action)
    .push(action)
    .push(action)
    .reverse()
    .submit()
    // Modify actions as normal again
    .add(action)
    .next()
    .clear()
    // ...
```