### PR TITLE
Add an anonymous action using a closure

### DIFF
--- a/examples/basic.rs
+++ b/examples/basic.rs
@@ -60,12 +60,25 @@ fn setup(mut commands: Commands) {
     commands.actions(actor).add(MyCustomAction);
 
     // Add an anonymous action using a closure
-    commands.actions(actor).add(
-        |entity, _world: &mut World, commands: &mut ActionCommands| {
-            // Do something...
-            commands.actions(entity).finish();
-        },
-    );
+    commands
+        .actions(actor)
+        // Single type closure S taking only the on_start method
+        .add(
+            |entity, _world: &mut World, commands: &mut ActionCommands| {
+                // on_start
+                commands.actions(entity).finish();
+            },
+        )
+        // Tuple closure (S1, S2) taking both on_start and on_stop methods
+        .add((
+            |entity, _world: &mut World, commands: &mut ActionCommands| {
+                // on_start
+                commands.actions(entity).finish();
+            },
+            |_entity, _world: &mut World, _reason| {
+                // on_stop
+            },
+        ));
 
     // Finally, quit the app
     commands.actions(actor).add(QuitAction);
@@ -108,7 +121,7 @@ impl Action for MyCustomAction {
                 LerpType::Position(CAMERA_OFFSET),
                 1.0,
             ))
-            .push(WaitAction::new(1.0))
+            .push(WaitAction::new(0.5))
             .push(LerpAction::new(
                 entity,
                 LerpType::Rotation(Quat::look_rotation(-Vec3::Z, Vec3::Y)),

--- a/examples/basic.rs
+++ b/examples/basic.rs
@@ -62,14 +62,14 @@ fn setup(mut commands: Commands) {
     // Add an anonymous action using a closure
     commands
         .actions(actor)
-        // Single type closure S taking only the on_start method
+        // Single closure for only the on_start method
         .add(
             |entity, _world: &mut World, commands: &mut ActionCommands| {
                 // on_start
                 commands.actions(entity).finish();
             },
         )
-        // Tuple closure (S1, S2) taking both on_start and on_stop methods
+        // Tuple closure for both the on_start and on_stop methods
         .add((
             |entity, _world: &mut World, commands: &mut ActionCommands| {
                 // on_start

--- a/examples/basic.rs
+++ b/examples/basic.rs
@@ -59,6 +59,14 @@ fn setup(mut commands: Commands) {
     // Add a custom action that itself adds other actions
     commands.actions(actor).add(MyCustomAction);
 
+    // Add an anonymous action using a closure
+    commands.actions(actor).add(
+        |entity, _world: &mut World, commands: &mut ActionCommands| {
+            // Do something...
+            commands.actions(entity).finish();
+        },
+    );
+
     // Finally, quit the app
     commands.actions(actor).add(QuitAction);
 }

--- a/src/traits.rs
+++ b/src/traits.rs
@@ -82,6 +82,17 @@ pub trait Action: Send + Sync {
     fn on_stop(&mut self, entity: Entity, world: &mut World, reason: StopReason);
 }
 
+impl<F> Action for F
+where
+    F: for<'w, 'a> FnMut(Entity, &'w mut World, &'a mut ActionCommands) + Send + Sync,
+{
+    fn on_start(&mut self, entity: Entity, world: &mut World, commands: &mut ActionCommands) {
+        (self)(entity, world, commands);
+    }
+
+    fn on_stop(&mut self, _entity: Entity, _world: &mut World, _reason: StopReason) {}
+}
+
 /// Conversion into an [`Action`].
 pub trait IntoAction {
     /// Convert `self` into `Box<dyn Action>`.

--- a/src/traits.rs
+++ b/src/traits.rs
@@ -84,7 +84,7 @@ pub trait Action: Send + Sync {
 
 impl<Start> Action for Start
 where
-    Start: for<'w, 'a> FnMut(Entity, &'w mut World, &'a mut ActionCommands) + Send + Sync,
+    Start: FnMut(Entity, &mut World, &mut ActionCommands) + Send + Sync,
 {
     fn on_start(&mut self, entity: Entity, world: &mut World, commands: &mut ActionCommands) {
         (self)(entity, world, commands);
@@ -95,8 +95,8 @@ where
 
 impl<Start, Stop> Action for (Start, Stop)
 where
-    Start: for<'w, 'a> FnMut(Entity, &'w mut World, &'a mut ActionCommands) + Send + Sync,
-    Stop: for<'w> FnMut(Entity, &'w mut World, StopReason) + Send + Sync,
+    Start: FnMut(Entity, &mut World, &mut ActionCommands) + Send + Sync,
+    Stop: FnMut(Entity, &mut World, StopReason) + Send + Sync,
 {
     fn on_start(&mut self, entity: Entity, world: &mut World, commands: &mut ActionCommands) {
         (self.0)(entity, world, commands);


### PR DESCRIPTION
```rust
commands
        .actions(actor)
        // Single closure for only the on_start method
        .add(
            |entity, _world: &mut World, commands: &mut ActionCommands| {
                // on_start
                commands.actions(entity).finish();
            },
        )
        // Tuple closure for both the on_start and on_stop methods
        .add((
            |entity, _world: &mut World, commands: &mut ActionCommands| {
                // on_start
                commands.actions(entity).finish();
            },
            |_entity, _world: &mut World, _reason| {
                // on_stop
            },
        ));
```