### PR TITLE
Replace `builder` constructs with `add_many` method

### DIFF
--- a/examples/pause.rs
+++ b/examples/pause.rs
@@ -23,7 +23,7 @@ fn setup(mut commands: Commands) {
     let min_rot = Vec3::ZERO;
     let max_rot = Vec3::Y * std::f32::consts::PI * 2.0;
 
-    for _ in 0..1 {
+    for _ in 0..10 {
         let actor = commands.spawn_actor(
             Vec3::random(min_move, max_move),
             Quat::random(min_rot, max_rot),

--- a/src/action_commands.rs
+++ b/src/action_commands.rs
@@ -43,7 +43,10 @@ impl ModifyActions for EntityActions<'_> {
         self
     }
 
-    fn add<T: IntoAction>(self, action: T) -> Self {
+    fn add<T>(self, action: T) -> Self
+    where
+        T: IntoBoxedAction,
+    {
         self.commands.0.push(ActionCommand::Add(
             self.entity,
             self.config,

--- a/src/action_commands.rs
+++ b/src/action_commands.rs
@@ -98,7 +98,7 @@ impl<'a> ModifyActions for EntityActions<'a> {
 /// Build a list of actions using [`ActionCommands`].
 pub struct ActionsBuilder<'a> {
     config: AddConfig,
-    actions: Vec<(Box<dyn Action>, AddConfig)>,
+    actions: Vec<(BoxedAction, AddConfig)>,
     modifier: EntityActions<'a>,
 }
 
@@ -133,7 +133,7 @@ impl<'a> ActionBuilder for ActionsBuilder<'a> {
 }
 
 enum ActionCommand {
-    Add(Entity, AddConfig, Box<dyn Action>),
+    Add(Entity, AddConfig, BoxedAction),
     Next(Entity),
     Finish(Entity),
     Pause(Entity),

--- a/src/action_commands.rs
+++ b/src/action_commands.rs
@@ -54,6 +54,18 @@ impl<'a> ModifyActions for EntityActions<'a> {
         self
     }
 
+    fn add_many<T>(self, actions: T) -> Self
+    where
+        T: BoxedActionIter,
+    {
+        self.commands.0.push(ActionCommand::AddMany(
+            self.entity,
+            self.config,
+            Box::new(actions),
+        ));
+        self
+    }
+
     fn next(self) -> Self {
         self.commands.0.push(ActionCommand::Next(self.entity));
         self
@@ -134,6 +146,7 @@ impl<'a> ActionBuilder for ActionsBuilder<'a> {
 
 enum ActionCommand {
     Add(Entity, AddConfig, BoxedAction),
+    AddMany(Entity, AddConfig, Box<dyn BoxedActionIter>),
     Next(Entity),
     Finish(Entity),
     Pause(Entity),
@@ -149,6 +162,9 @@ impl ActionCommands {
             match cmd {
                 ActionCommand::Add(entity, config, action) => {
                     world.actions(entity).config(config).add(action);
+                }
+                ActionCommand::AddMany(entity, config, actions) => {
+                    world.actions(entity).config(config).add_many(actions);
                 }
                 ActionCommand::Next(entity) => {
                     world.actions(entity).next();

--- a/src/action_commands.rs
+++ b/src/action_commands.rs
@@ -25,7 +25,7 @@ pub struct EntityActions<'a> {
     commands: &'a mut ActionCommands,
 }
 
-impl<'a> EntityActions<'a> {
+impl EntityActions<'_> {
     /// Mutate [`World`] with `f` after [`Action::on_start`] has been called.
     /// Used for modifying actions in a deferred way using [`World`] inside the [`Action`] trait.
     pub fn custom<F>(self, f: F) -> Self
@@ -37,9 +37,7 @@ impl<'a> EntityActions<'a> {
     }
 }
 
-impl<'a> ModifyActions for EntityActions<'a> {
-    type Builder = ActionsBuilder<'a>;
-
+impl ModifyActions for EntityActions<'_> {
     fn config(mut self, config: AddConfig) -> Self {
         self.config = config;
         self
@@ -96,51 +94,6 @@ impl<'a> ModifyActions for EntityActions<'a> {
     fn clear(self) -> Self {
         self.commands.0.push(ActionCommand::Clear(self.entity));
         self
-    }
-
-    fn builder(self) -> Self::Builder {
-        ActionsBuilder {
-            config: AddConfig::default(),
-            actions: Vec::new(),
-            modifier: self,
-        }
-    }
-}
-
-/// Build a list of actions using [`ActionCommands`].
-pub struct ActionsBuilder<'a> {
-    config: AddConfig,
-    actions: Vec<(BoxedAction, AddConfig)>,
-    modifier: EntityActions<'a>,
-}
-
-impl<'a> ActionBuilder for ActionsBuilder<'a> {
-    type Modifier = EntityActions<'a>;
-
-    fn config(mut self, config: AddConfig) -> Self {
-        self.config = config;
-        self
-    }
-
-    fn push<T: IntoAction>(mut self, action: T) -> Self {
-        self.actions.push((action.into_boxed(), self.config));
-        self
-    }
-
-    fn reverse(mut self) -> Self {
-        self.actions.reverse();
-        self
-    }
-
-    fn submit(self) -> Self::Modifier {
-        for (action, config) in self.actions {
-            self.modifier
-                .commands
-                .0
-                .push(ActionCommand::Add(self.modifier.entity, config, action));
-        }
-
-        self.modifier
     }
 }
 

--- a/src/commands.rs
+++ b/src/commands.rs
@@ -90,7 +90,7 @@ impl<'w, 's, 'a> ModifyActions for EntityCommandsActions<'w, 's, 'a> {
 /// Build a list of actions using [`Commands`].
 pub struct ActionCommandsBuilder<'w, 's, 'a> {
     config: AddConfig,
-    actions: Vec<(Box<dyn Action>, AddConfig)>,
+    actions: Vec<(BoxedAction, AddConfig)>,
     modifier: EntityCommandsActions<'w, 's, 'a>,
 }
 

--- a/src/commands.rs
+++ b/src/commands.rs
@@ -2,10 +2,10 @@ use bevy_ecs::prelude::*;
 
 use crate::*;
 
-impl<'w: 'a, 's: 'a, 'a> ActionsProxy<'a> for Commands<'w, 's> {
-    type Modifier = EntityCommandsActions<'w, 's, 'a>;
+impl<'c, 'w: 'c, 's: 'c> ActionsProxy<'c> for Commands<'w, 's> {
+    type Modifier = EntityCommandsActions<'c, 'w, 's>;
 
-    fn actions(&'a mut self, entity: Entity) -> EntityCommandsActions<'w, 's, 'a> {
+    fn actions(&'c mut self, entity: Entity) -> EntityCommandsActions<'c, 'w, 's> {
         EntityCommandsActions {
             entity,
             config: AddConfig::default(),
@@ -15,15 +15,13 @@ impl<'w: 'a, 's: 'a, 'a> ActionsProxy<'a> for Commands<'w, 's> {
 }
 
 /// Modify actions using [`Commands`].
-pub struct EntityCommandsActions<'w, 's, 'a> {
+pub struct EntityCommandsActions<'c, 'w, 's> {
     entity: Entity,
     config: AddConfig,
-    commands: &'a mut Commands<'w, 's>,
+    commands: &'c mut Commands<'w, 's>,
 }
 
-impl<'w, 's, 'a> ModifyActions for EntityCommandsActions<'w, 's, 'a> {
-    type Builder = ActionCommandsBuilder<'w, 's, 'a>;
-
+impl ModifyActions for EntityCommandsActions<'_, '_, '_> {
     fn config(mut self, config: AddConfig) -> Self {
         self.config = config;
         self
@@ -92,50 +90,5 @@ impl<'w, 's, 'a> ModifyActions for EntityCommandsActions<'w, 's, 'a> {
             world.actions(self.entity).clear();
         });
         self
-    }
-
-    fn builder(self) -> Self::Builder {
-        ActionCommandsBuilder {
-            config: AddConfig::default(),
-            actions: Vec::new(),
-            modifier: self,
-        }
-    }
-}
-
-/// Build a list of actions using [`Commands`].
-pub struct ActionCommandsBuilder<'w, 's, 'a> {
-    config: AddConfig,
-    actions: Vec<(BoxedAction, AddConfig)>,
-    modifier: EntityCommandsActions<'w, 's, 'a>,
-}
-
-impl<'w, 's, 'a> ActionBuilder for ActionCommandsBuilder<'w, 's, 'a> {
-    type Modifier = EntityCommandsActions<'w, 's, 'a>;
-
-    fn config(mut self, config: AddConfig) -> Self {
-        self.config = config;
-        self
-    }
-
-    fn push<T: IntoAction>(mut self, action: T) -> Self {
-        self.actions.push((action.into_boxed(), self.config));
-        self
-    }
-
-    fn reverse(mut self) -> Self {
-        self.actions.reverse();
-        self
-    }
-
-    fn submit(self) -> Self::Modifier {
-        self.modifier.commands.add(move |world: &mut World| {
-            let mut wa = world.actions(self.modifier.entity);
-            for (action, config) in self.actions {
-                wa = wa.config(config).add(action);
-            }
-        });
-
-        self.modifier
     }
 }

--- a/src/commands.rs
+++ b/src/commands.rs
@@ -29,7 +29,7 @@ impl ModifyActions for EntityCommandsActions<'_, '_, '_> {
 
     fn add<T>(self, action: T) -> Self
     where
-        T: IntoAction,
+        T: IntoBoxedAction,
     {
         self.commands.add(move |world: &mut World| {
             world.actions(self.entity).config(self.config).add(action);

--- a/src/commands.rs
+++ b/src/commands.rs
@@ -29,9 +29,25 @@ impl<'w, 's, 'a> ModifyActions for EntityCommandsActions<'w, 's, 'a> {
         self
     }
 
-    fn add<T: IntoAction>(self, action: T) -> Self {
+    fn add<T>(self, action: T) -> Self
+    where
+        T: IntoAction,
+    {
         self.commands.add(move |world: &mut World| {
             world.actions(self.entity).config(self.config).add(action);
+        });
+        self
+    }
+
+    fn add_many<T>(self, actions: T) -> Self
+    where
+        T: BoxedActionIter,
+    {
+        self.commands.add(move |world: &mut World| {
+            world
+                .actions(self.entity)
+                .config(self.config)
+                .add_many(actions);
         });
         self
     }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -117,7 +117,10 @@ pub enum StopReason {
     Paused,
 }
 
-type ActionTuple = (Box<dyn Action>, ActionConfig);
+/// A boxed [`Action`].
+pub type BoxedAction = Box<dyn Action>;
+
+type ActionTuple = (BoxedAction, ActionConfig);
 
 #[derive(Default, Component)]
 struct ActionQueue(VecDeque<ActionTuple>);

--- a/src/traits.rs
+++ b/src/traits.rs
@@ -176,7 +176,14 @@ pub trait ModifyActions {
     fn config(self, config: AddConfig) -> Self;
 
     /// Adds an [`action`](Action) to the queue with the current [`config`](AddConfig).
-    fn add<T: IntoAction>(self, action: T) -> Self;
+    fn add<T>(self, action: T) -> Self
+    where
+        T: IntoAction;
+
+    /// Adds a collection of [`actions`](Action) to the queue with the current [`config`](AddConfig).
+    fn add_many<T>(self, actions: T) -> Self
+    where
+        T: DoubleEndedIterator<Item = BoxedAction>;
 
     /// [`Starts`](Action::on_start) the next [`action`](Action) in the queue.
     /// Current action is [`stopped`](Action::on_stop) as [`canceled`](StopReason::Canceled).

--- a/src/traits.rs
+++ b/src/traits.rs
@@ -107,13 +107,13 @@ where
     }
 }
 
-/// Conversion into an [`Action`].
-pub trait IntoAction: Send + Sync + 'static {
+/// Conversion into a [`BoxedAction`].
+pub trait IntoBoxedAction: Send + Sync + 'static {
     /// Convert `self` into [`BoxedAction`].
     fn into_boxed(self) -> BoxedAction;
 }
 
-impl<T> IntoAction for T
+impl<T> IntoBoxedAction for T
 where
     T: Action,
 {
@@ -122,13 +122,13 @@ where
     }
 }
 
-impl IntoAction for BoxedAction {
+impl IntoBoxedAction for BoxedAction {
     fn into_boxed(self) -> BoxedAction {
         self
     }
 }
 
-/// Blanket trait signature for adding a collection of actions.
+/// Trait alias for a collection of actions.
 pub trait BoxedActionIter: DoubleEndedIterator<Item = BoxedAction> + Send + Sync + 'static {}
 
 impl<T> BoxedActionIter for T where
@@ -183,7 +183,7 @@ pub trait ModifyActions {
     /// Adds an [`action`](Action) to the queue with the current [`config`](AddConfig).
     fn add<T>(self, action: T) -> Self
     where
-        T: IntoAction;
+        T: IntoBoxedAction;
 
     /// Adds a collection of [`actions`](Action) to the queue with the current [`config`](AddConfig).
     fn add_many<T>(self, actions: T) -> Self

--- a/src/traits.rs
+++ b/src/traits.rs
@@ -128,6 +128,11 @@ impl IntoAction for BoxedAction {
     }
 }
 
+/// Blanket trait signature for adding a collection of actions.
+pub trait BoxedActionIter: DoubleEndedIterator<Item = BoxedAction> + Send + Sync + 'static {}
+
+impl BoxedActionIter for Box<dyn BoxedActionIter> {}
+
 /// Proxy method for modifying actions. Returns a type that implements [`ModifyActions`].
 ///
 /// # Warning
@@ -183,7 +188,7 @@ pub trait ModifyActions {
     /// Adds a collection of [`actions`](Action) to the queue with the current [`config`](AddConfig).
     fn add_many<T>(self, actions: T) -> Self
     where
-        T: DoubleEndedIterator<Item = BoxedAction>;
+        T: BoxedActionIter;
 
     /// [`Starts`](Action::on_start) the next [`action`](Action) in the queue.
     /// Current action is [`stopped`](Action::on_stop) as [`canceled`](StopReason::Canceled).

--- a/src/traits.rs
+++ b/src/traits.rs
@@ -109,21 +109,21 @@ where
 
 /// Conversion into an [`Action`].
 pub trait IntoAction: Send + Sync + 'static {
-    /// Convert `self` into `Box<dyn Action>`.
-    fn into_boxed(self) -> Box<dyn Action>;
+    /// Convert `self` into [`BoxedAction`].
+    fn into_boxed(self) -> BoxedAction;
 }
 
 impl<T> IntoAction for T
 where
     T: Action,
 {
-    fn into_boxed(self) -> Box<dyn Action> {
+    fn into_boxed(self) -> BoxedAction {
         Box::new(self)
     }
 }
 
-impl IntoAction for Box<dyn Action> {
-    fn into_boxed(self) -> Box<dyn Action> {
+impl IntoAction for BoxedAction {
+    fn into_boxed(self) -> BoxedAction {
         self
     }
 }

--- a/src/world.rs
+++ b/src/world.rs
@@ -37,9 +37,9 @@ impl<'a> ModifyActions for EntityWorldActions<'a> {
         self
     }
 
-    fn add_many<T>(self, actions: T) -> Self
+    fn add_many<T>(mut self, actions: T) -> Self
     where
-        T: DoubleEndedIterator<Item = BoxedAction>,
+        T: BoxedActionIter,
     {
         let mut queue = self.world.get_mut::<ActionQueue>(self.entity).unwrap();
 
@@ -151,10 +151,10 @@ impl<'a> ActionBuilder for ActionWorldBuilder<'a> {
 impl EntityWorldActions<'_> {
     fn add_action<T: IntoAction>(&mut self, action: T, config: AddConfig) {
         let action_tuple = (action.into_boxed(), config.into());
-        let mut actions = self.world.get_mut::<ActionQueue>(self.entity).unwrap();
+        let mut queue = self.world.get_mut::<ActionQueue>(self.entity).unwrap();
         match config.order {
-            AddOrder::Front => actions.push_front(action_tuple),
-            AddOrder::Back => actions.push_back(action_tuple),
+            AddOrder::Front => queue.push_front(action_tuple),
+            AddOrder::Back => queue.push_back(action_tuple),
         }
 
         if config.start && !self.has_current_action() {
@@ -215,3 +215,17 @@ impl EntityWorldActions<'_> {
             .is_some()
     }
 }
+
+// pub(super) trait WorldHelperExt {
+//     fn add_action<T>(&mut self, entity: Entity, action: T, config: AddConfig)
+//     where
+//         T: IntoAction;
+//     fn add_many_actions<T>(&mut self, entity: Entity, actions: T)
+//     where
+//         T: DoubleEndedIterator<Item = BoxedAction>;
+//     fn stop_current_action(&mut self, entity: Entity, reason: StopReason);
+//     fn start_next_action(&mut self, entity: Entity);
+//     fn take_current_action(&mut self, entity: Entity) -> Option<ActionTuple>;
+//     fn pop_next_action(&mut self, entity: Entity) -> Option<ActionTuple>;
+//     fn has_current_action(&self, entity: Entity) -> bool;
+// }

--- a/src/world.rs
+++ b/src/world.rs
@@ -29,7 +29,7 @@ impl ModifyActions for EntityWorldActions<'_> {
 
     fn add<T>(mut self, action: T) -> Self
     where
-        T: IntoAction,
+        T: IntoBoxedAction,
     {
         let mut queue = self.world.get_mut::<ActionQueue>(self.entity).unwrap();
         let action_tuple = (action.into_boxed(), self.config.into());
@@ -169,17 +169,3 @@ impl EntityWorldActions<'_> {
             .is_some()
     }
 }
-
-// pub(super) trait WorldHelperExt {
-//     fn add_action<T>(&mut self, entity: Entity, action: T, config: AddConfig)
-//     where
-//         T: IntoAction;
-//     fn add_many_actions<T>(&mut self, entity: Entity, actions: T)
-//     where
-//         T: DoubleEndedIterator<Item = BoxedAction>;
-//     fn stop_current_action(&mut self, entity: Entity, reason: StopReason);
-//     fn start_next_action(&mut self, entity: Entity);
-//     fn take_current_action(&mut self, entity: Entity) -> Option<ActionTuple>;
-//     fn pop_next_action(&mut self, entity: Entity) -> Option<ActionTuple>;
-//     fn has_current_action(&self, entity: Entity) -> bool;
-// }

--- a/src/world.rs
+++ b/src/world.rs
@@ -88,7 +88,7 @@ impl<'a> ModifyActions for EntityWorldActions<'a> {
 /// Build a list of actions using [`World`].
 pub struct ActionWorldBuilder<'a> {
     config: AddConfig,
-    actions: Vec<(Box<dyn Action>, AddConfig)>,
+    actions: Vec<(BoxedAction, AddConfig)>,
     modifier: EntityWorldActions<'a>,
 }
 

--- a/src/world.rs
+++ b/src/world.rs
@@ -15,15 +15,13 @@ impl<'a> ActionsProxy<'a> for World {
 }
 
 /// Modify actions using [`World`].
-pub struct EntityWorldActions<'a> {
+pub struct EntityWorldActions<'w> {
     entity: Entity,
     config: AddConfig,
-    world: &'a mut World,
+    world: &'w mut World,
 }
 
-impl<'a> ModifyActions for EntityWorldActions<'a> {
-    type Builder = ActionWorldBuilder<'a>;
-
+impl ModifyActions for EntityWorldActions<'_> {
     fn config(mut self, config: AddConfig) -> Self {
         self.config = config;
         self
@@ -33,7 +31,18 @@ impl<'a> ModifyActions for EntityWorldActions<'a> {
     where
         T: IntoAction,
     {
-        self.add_action(action, self.config);
+        let mut queue = self.world.get_mut::<ActionQueue>(self.entity).unwrap();
+        let action_tuple = (action.into_boxed(), self.config.into());
+
+        match self.config.order {
+            AddOrder::Back => queue.push_back(action_tuple),
+            AddOrder::Front => queue.push_front(action_tuple),
+        }
+
+        if self.config.start && !self.has_current_action() {
+            self.start_next_action();
+        }
+
         self
     }
 
@@ -50,8 +59,8 @@ impl<'a> ModifyActions for EntityWorldActions<'a> {
                 }
             }
             AddOrder::Front => {
-                for action in actions.into_iter().rev() {
-                    queue.push_back((action, self.config.into()));
+                for action in actions.rev() {
+                    queue.push_front((action, self.config.into()));
                 }
             }
         }
@@ -104,64 +113,9 @@ impl<'a> ModifyActions for EntityWorldActions<'a> {
 
         self
     }
-
-    fn builder(self) -> Self::Builder {
-        ActionWorldBuilder {
-            config: AddConfig::default(),
-            actions: Vec::new(),
-            modifier: self,
-        }
-    }
-}
-
-/// Build a list of actions using [`World`].
-pub struct ActionWorldBuilder<'a> {
-    config: AddConfig,
-    actions: Vec<(BoxedAction, AddConfig)>,
-    modifier: EntityWorldActions<'a>,
-}
-
-impl<'a> ActionBuilder for ActionWorldBuilder<'a> {
-    type Modifier = EntityWorldActions<'a>;
-
-    fn config(mut self, config: AddConfig) -> Self {
-        self.config = config;
-        self
-    }
-
-    fn push<T: IntoAction>(mut self, action: T) -> Self {
-        self.actions.push((action.into_boxed(), self.config));
-        self
-    }
-
-    fn reverse(mut self) -> Self {
-        self.actions.reverse();
-        self
-    }
-
-    fn submit(mut self) -> Self::Modifier {
-        for (action, config) in self.actions {
-            self.modifier.add_action(action, config);
-        }
-
-        self.modifier
-    }
 }
 
 impl EntityWorldActions<'_> {
-    fn add_action<T: IntoAction>(&mut self, action: T, config: AddConfig) {
-        let action_tuple = (action.into_boxed(), config.into());
-        let mut queue = self.world.get_mut::<ActionQueue>(self.entity).unwrap();
-        match config.order {
-            AddOrder::Front => queue.push_front(action_tuple),
-            AddOrder::Back => queue.push_back(action_tuple),
-        }
-
-        if config.start && !self.has_current_action() {
-            self.start_next_action();
-        }
-    }
-
     fn stop_current_action(&mut self, reason: StopReason) {
         if let Some((mut action, cfg)) = self.take_current_action() {
             action.on_stop(self.entity, self.world, reason);


### PR DESCRIPTION
Remove all builder stuff in favor of simply having a method that takes an iterator of boxed actions.