### PR TITLE
Replace repeat bool with a `Repeat` enum

### DIFF
--- a/README.md
+++ b/README.md
@@ -41,7 +41,7 @@ Consider running with `--release` as debug builds can be quite slow.
 | -------- | -------------------------------------------------------------------------------------- |
 | `basic`  | Shows the basic usage of the library by adding some actions and then quitting the app. |
 | `pause`  | Shows how to pause and resume an action when pressing `space`.                         |
-| `repeat` | Shows how to add actions that basically loop forever in the added order.               |
+| `repeat` | Shows how to add actions that repeat `n` times and forever.                            |
 
 ## Compatibility
 

--- a/README.md
+++ b/README.md
@@ -22,10 +22,10 @@ fn setup(mut commands: Commands) {
         .config(AddConfig {
             // Add each action to the back of the queue
             order: AddOrder::Back,
-            // Start action if nothing is currently running
+            // Start the next action in the queue if nothing is currently running
             start: true,
-            // Repeat the action
-            repeat: false,
+            // Repeat the action `n` times
+            repeat: Repeat::Finite(0),
         })
         .add(move_action)
         .add(quit_action);

--- a/README.md
+++ b/README.md
@@ -25,7 +25,7 @@ fn setup(mut commands: Commands) {
             // Start the next action in the queue if nothing is currently running
             start: true,
             // Repeat the action `n` times
-            repeat: Repeat::Finite(0),
+            repeat: AddRepeat::Finite(0),
         })
         .add(move_action)
         .add(quit_action);

--- a/README.md
+++ b/README.md
@@ -25,7 +25,7 @@ fn setup(mut commands: Commands) {
             // Start the next action in the queue if nothing is currently running
             start: true,
             // Repeat the action `n` times
-            repeat: AddRepeat::Finite(0),
+            repeat: Repeat::Amount(0),
         })
         .add(move_action)
         .add(quit_action);

--- a/examples/basic.rs
+++ b/examples/basic.rs
@@ -32,7 +32,7 @@ fn setup(mut commands: Commands) {
             // Start action if nothing is currently running
             start: true,
             // Repeat the action
-            repeat: false,
+            repeat: Repeat::Finite(0),
         })
         .add(MoveAction::new(-Vec3::X * 2.0))
         .add(WaitAction::new(1.0))
@@ -128,7 +128,7 @@ impl Action for MyCustomAction {
             .config(AddConfig {
                 order: AddOrder::Front,
                 start: false,
-                repeat: false,
+                repeat: Repeat::Finite(0),
             })
             .add_many(actions.into_iter())
             .finish();

--- a/examples/basic.rs
+++ b/examples/basic.rs
@@ -32,7 +32,7 @@ fn setup(mut commands: Commands) {
             // Start action if nothing is currently running
             start: true,
             // Repeat the action zero times, i.e. run only once
-            repeat: AddRepeat::Finite(0),
+            repeat: Repeat::Amount(0),
         })
         .add(MoveAction::new(-Vec3::X * 2.0))
         .add(WaitAction::new(1.0))
@@ -128,7 +128,7 @@ impl Action for MyCustomAction {
             .config(AddConfig {
                 order: AddOrder::Front,
                 start: false,
-                repeat: AddRepeat::Finite(0),
+                repeat: Repeat::Amount(0),
             })
             .add_many(actions.into_iter())
             .finish();

--- a/examples/basic.rs
+++ b/examples/basic.rs
@@ -31,7 +31,7 @@ fn setup(mut commands: Commands) {
             order: AddOrder::Back,
             // Start action if nothing is currently running
             start: true,
-            // Repeat the action
+            // Repeat the action zero times, i.e. run only once
             repeat: Repeat::Finite(0),
         })
         .add(MoveAction::new(-Vec3::X * 2.0))

--- a/examples/basic.rs
+++ b/examples/basic.rs
@@ -32,7 +32,7 @@ fn setup(mut commands: Commands) {
             // Start action if nothing is currently running
             start: true,
             // Repeat the action zero times, i.e. run only once
-            repeat: Repeat::Finite(0),
+            repeat: AddRepeat::Finite(0),
         })
         .add(MoveAction::new(-Vec3::X * 2.0))
         .add(WaitAction::new(1.0))
@@ -128,7 +128,7 @@ impl Action for MyCustomAction {
             .config(AddConfig {
                 order: AddOrder::Front,
                 start: false,
-                repeat: Repeat::Finite(0),
+                repeat: AddRepeat::Finite(0),
             })
             .add_many(actions.into_iter())
             .finish();

--- a/examples/pause.rs
+++ b/examples/pause.rs
@@ -34,7 +34,7 @@ fn setup(mut commands: Commands) {
             .config(AddConfig {
                 order: AddOrder::Back,
                 start: true,
-                repeat: true,
+                repeat: Repeat::Infinite,
             })
             .add(WaitRandomAction::new(min_wait, max_wait))
             .add(RotateRandomAction::new(min_rot, max_rot))

--- a/examples/pause.rs
+++ b/examples/pause.rs
@@ -34,7 +34,7 @@ fn setup(mut commands: Commands) {
             .config(AddConfig {
                 order: AddOrder::Back,
                 start: true,
-                repeat: AddRepeat::Infinite,
+                repeat: Repeat::Forever,
             })
             .add(WaitRandomAction::new(min_wait, max_wait))
             .add(RotateRandomAction::new(min_rot, max_rot))

--- a/examples/pause.rs
+++ b/examples/pause.rs
@@ -34,7 +34,7 @@ fn setup(mut commands: Commands) {
             .config(AddConfig {
                 order: AddOrder::Back,
                 start: true,
-                repeat: Repeat::Infinite,
+                repeat: AddRepeat::Infinite,
             })
             .add(WaitRandomAction::new(min_wait, max_wait))
             .add(RotateRandomAction::new(min_rot, max_rot))

--- a/examples/repeat.rs
+++ b/examples/repeat.rs
@@ -20,8 +20,8 @@ fn setup(mut commands: Commands) {
         let actor = commands.spawn_actor(start, Quat::look_rotation(Vec3::Z, Vec3::Y));
 
         let repeat = match i {
-            3 => Repeat::Infinite,
-            _ => Repeat::Finite(i),
+            3 => AddRepeat::Infinite,
+            _ => AddRepeat::Finite(i),
         };
 
         commands

--- a/examples/repeat.rs
+++ b/examples/repeat.rs
@@ -1,7 +1,7 @@
 use bevy::prelude::*;
 use bevy_sequential_actions::*;
 
-use shared::{actions::*, bootstrap::*};
+use shared::{actions::*, bootstrap::*, extensions::LookRotationExt};
 
 fn main() {
     App::new()
@@ -13,21 +13,27 @@ fn main() {
 }
 
 fn setup(mut commands: Commands) {
-    let actor = commands.spawn_actor(Vec3::ZERO, Quat::IDENTITY);
+    for i in 0..4 {
+        let start = Vec3::new(-3.0, 0.0, -2.0) + Vec3::X * i as f32 * 2.0;
+        let end = start + Vec3::Z * 4.0;
 
-    let min_wait = 0.5;
-    let max_wait = 2.0;
+        let actor = commands.spawn_actor(start, Quat::look_rotation(Vec3::Z, Vec3::Y));
 
-    let min_move = Vec3::new(-7.0, 0.0, -4.0);
-    let max_move = min_move * -1.0;
+        let repeat = match i {
+            3 => Repeat::Infinite,
+            _ => Repeat::Finite(i),
+        };
 
-    commands
-        .actions(actor)
-        .config(AddConfig {
-            order: AddOrder::Back,
-            start: true,
-            repeat: Repeat::Finite(1),
-        })
-        .add(WaitRandomAction::new(min_wait, max_wait))
-        .add(MoveRandomAction::new(min_move, max_move));
+        commands
+            .actions(actor)
+            .config(AddConfig {
+                order: AddOrder::Back,
+                start: true,
+                repeat,
+            })
+            .add(WaitAction::new(0.5))
+            .add(MoveAction::new(end))
+            .add(WaitAction::new(0.5))
+            .add(MoveAction::new(start));
+    }
 }

--- a/examples/repeat.rs
+++ b/examples/repeat.rs
@@ -26,7 +26,7 @@ fn setup(mut commands: Commands) {
         .config(AddConfig {
             order: AddOrder::Back,
             start: true,
-            repeat: true,
+            repeat: Repeat::Finite(1),
         })
         .add(WaitRandomAction::new(min_wait, max_wait))
         .add(MoveRandomAction::new(min_move, max_move));

--- a/examples/repeat.rs
+++ b/examples/repeat.rs
@@ -20,8 +20,8 @@ fn setup(mut commands: Commands) {
         let actor = commands.spawn_actor(start, Quat::look_rotation(Vec3::Z, Vec3::Y));
 
         let repeat = match i {
-            3 => AddRepeat::Infinite,
-            _ => AddRepeat::Finite(i),
+            3 => Repeat::Forever,
+            _ => Repeat::Amount(i),
         };
 
         commands

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -92,8 +92,8 @@ pub struct AddConfig {
     pub order: AddOrder,
     /// Start the next [`action`](Action) in the queue if nothing is currently running.
     pub start: bool,
-    /// Repeat the [`action`](Action) by adding it back to the queue when it is removed.
-    pub repeat: bool,
+    /// Specify how many times the [`action`](Action) should run.
+    pub repeat: Repeat,
 }
 
 impl Default for AddConfig {
@@ -101,9 +101,15 @@ impl Default for AddConfig {
         Self {
             order: AddOrder::Back,
             start: true,
-            repeat: false,
+            repeat: Repeat::Finite(0),
         }
     }
+}
+
+#[derive(Clone, Copy)]
+pub enum Repeat {
+    Finite(usize),
+    Infinite,
 }
 
 /// The reason why an [`Action`] was stopped.
@@ -129,7 +135,7 @@ struct ActionQueue(VecDeque<ActionTuple>);
 struct CurrentAction(Option<ActionTuple>);
 
 struct ActionConfig {
-    repeat: bool,
+    repeat: Repeat,
 }
 
 impl From<AddConfig> for ActionConfig {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -76,15 +76,6 @@ pub struct ActionsBundle {
 #[derive(Default, Component)]
 pub struct ActionMarker;
 
-/// The queue order for an [`Action`] to be added.
-#[derive(Clone, Copy)]
-pub enum AddOrder {
-    /// An [`action`](Action) is added to the back of the queue.
-    Back,
-    /// An [`action`](Action) is added to the front of the queue.
-    Front,
-}
-
 /// Configuration for an [`Action`] to be added.
 #[derive(Clone, Copy)]
 pub struct AddConfig {
@@ -92,7 +83,7 @@ pub struct AddConfig {
     pub order: AddOrder,
     /// Start the next [`action`](Action) in the queue if nothing is currently running.
     pub start: bool,
-    /// Specify how many times the [`action`](Action) should run.
+    /// Specify how many times the [`action`](Action) should be repeated.
     pub repeat: Repeat,
 }
 
@@ -106,7 +97,16 @@ impl Default for AddConfig {
     }
 }
 
-/// Specify how many times an [`Action`] should be repeated.
+/// The queue order for an [`Action`] to be added.
+#[derive(Clone, Copy)]
+pub enum AddOrder {
+    /// An [`action`](Action) is added to the back of the queue.
+    Back,
+    /// An [`action`](Action) is added to the front of the queue.
+    Front,
+}
+
+/// The repeat configuration for an [`Action`] to be added.
 #[derive(Clone, Copy)]
 pub enum Repeat {
     /// Repeat the [`action`](Action) `n` times.

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -37,7 +37,7 @@
 //!             // Start the next action in the queue if nothing is currently running
 //!             start: true,
 //!             // Repeat the action `n` times
-//!             repeat: AddRepeat::Finite(0),
+//!             repeat: Repeat::Amount(0),
 //!         })
 //!         .add(move_action)
 //!         .add(quit_action);
@@ -84,7 +84,7 @@ pub struct AddConfig {
     /// Start the next [`action`](Action) in the queue if nothing is currently running.
     pub start: bool,
     /// Specify how many times the [`action`](Action) should be repeated.
-    pub repeat: AddRepeat,
+    pub repeat: Repeat,
 }
 
 impl Default for AddConfig {
@@ -92,7 +92,7 @@ impl Default for AddConfig {
         Self {
             order: AddOrder::Back,
             start: true,
-            repeat: AddRepeat::Finite(0),
+            repeat: Repeat::Amount(0),
         }
     }
 }
@@ -108,11 +108,11 @@ pub enum AddOrder {
 
 /// The repeat configuration for an [`Action`] to be added.
 #[derive(Clone, Copy)]
-pub enum AddRepeat {
+pub enum Repeat {
     /// Repeat the [`action`](Action) `n` times.
-    Finite(u32),
+    Amount(u32),
     /// Repeat the [`action`](Action) forever.
-    Infinite,
+    Forever,
 }
 
 /// The reason why an [`Action`] was stopped.
@@ -138,7 +138,7 @@ struct ActionQueue(VecDeque<ActionTuple>);
 struct CurrentAction(Option<ActionTuple>);
 
 struct ActionConfig {
-    repeat: AddRepeat,
+    repeat: Repeat,
 }
 
 impl From<AddConfig> for ActionConfig {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -37,7 +37,7 @@
 //!             // Start the next action in the queue if nothing is currently running
 //!             start: true,
 //!             // Repeat the action `n` times
-//!             repeat: Repeat::Finite(0),
+//!             repeat: AddRepeat::Finite(0),
 //!         })
 //!         .add(move_action)
 //!         .add(quit_action);
@@ -84,7 +84,7 @@ pub struct AddConfig {
     /// Start the next [`action`](Action) in the queue if nothing is currently running.
     pub start: bool,
     /// Specify how many times the [`action`](Action) should be repeated.
-    pub repeat: Repeat,
+    pub repeat: AddRepeat,
 }
 
 impl Default for AddConfig {
@@ -92,7 +92,7 @@ impl Default for AddConfig {
         Self {
             order: AddOrder::Back,
             start: true,
-            repeat: Repeat::Finite(0),
+            repeat: AddRepeat::Finite(0),
         }
     }
 }
@@ -108,7 +108,7 @@ pub enum AddOrder {
 
 /// The repeat configuration for an [`Action`] to be added.
 #[derive(Clone, Copy)]
-pub enum Repeat {
+pub enum AddRepeat {
     /// Repeat the [`action`](Action) `n` times.
     Finite(u32),
     /// Repeat the [`action`](Action) forever.
@@ -138,7 +138,7 @@ struct ActionQueue(VecDeque<ActionTuple>);
 struct CurrentAction(Option<ActionTuple>);
 
 struct ActionConfig {
-    repeat: Repeat,
+    repeat: AddRepeat,
 }
 
 impl From<AddConfig> for ActionConfig {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -36,8 +36,8 @@
 //!             order: AddOrder::Back,
 //!             // Start the next action in the queue if nothing is currently running
 //!             start: true,
-//!             // Repeat the action by adding it back to the queue when it is removed
-//!             repeat: false,
+//!             // Repeat the action `n` times
+//!             repeat: Repeat::Finite(0),
 //!         })
 //!         .add(move_action)
 //!         .add(quit_action);
@@ -106,9 +106,12 @@ impl Default for AddConfig {
     }
 }
 
+/// Specify how many times an [`Action`] should be repeated.
 #[derive(Clone, Copy)]
 pub enum Repeat {
+    /// Repeat the [`action`](Action) `n` times.
     Finite(usize),
+    /// Repeat the [`action`](Action) forever.
     Infinite,
 }
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -110,7 +110,7 @@ pub enum AddOrder {
 #[derive(Clone, Copy)]
 pub enum Repeat {
     /// Repeat the [`action`](Action) `n` times.
-    Finite(usize),
+    Finite(u32),
     /// Repeat the [`action`](Action) forever.
     Infinite,
 }

--- a/src/tests.rs
+++ b/src/tests.rs
@@ -327,7 +327,7 @@ fn push() {
 }
 
 #[test]
-fn repeat_finite() {
+fn repeat_amount() {
     let mut ecs = Ecs::new();
     let e = ecs.spawn_action_entity();
 
@@ -364,7 +364,7 @@ fn repeat_finite() {
 }
 
 #[test]
-fn repeat_infinite() {
+fn repeat_forever() {
     let mut ecs = Ecs::new();
     let e = ecs.spawn_action_entity();
 

--- a/src/tests.rs
+++ b/src/tests.rs
@@ -229,14 +229,19 @@ fn skip() {
         .config(AddConfig {
             order: AddOrder::Back,
             start: false,
-            repeat: false,
+            repeat: Repeat::Finite(0),
         })
-        .add(EmptyAction)
         .add(EmptyAction)
         .config(AddConfig {
             order: AddOrder::Back,
             start: false,
-            repeat: true,
+            repeat: Repeat::Finite(1),
+        })
+        .add(EmptyAction)
+        .config(AddConfig {
+            order: AddOrder::Back,
+            start: false,
+            repeat: Repeat::Infinite,
         })
         .add(EmptyAction);
 
@@ -245,6 +250,18 @@ fn skip() {
     ecs.actions(e).skip();
 
     assert!(ecs.get_action_queue(e).len() == 2);
+
+    ecs.actions(e).skip();
+
+    assert!(ecs.get_action_queue(e).len() == 2);
+
+    ecs.actions(e).skip();
+
+    assert!(ecs.get_action_queue(e).len() == 2);
+
+    ecs.actions(e).skip();
+
+    assert!(ecs.get_action_queue(e).len() == 1);
 
     ecs.actions(e).skip();
 
@@ -310,7 +327,7 @@ fn push() {
 }
 
 #[test]
-fn repeat() {
+fn repeat_finite() {
     let mut ecs = Ecs::new();
     let e = ecs.spawn_action_entity();
 
@@ -318,7 +335,44 @@ fn repeat() {
         .config(AddConfig {
             order: AddOrder::Back,
             start: true,
-            repeat: true,
+            repeat: Repeat::Finite(0),
+        })
+        .add(CountdownAction::new(0))
+        .config(AddConfig {
+            order: AddOrder::Back,
+            start: true,
+            repeat: Repeat::Finite(1),
+        })
+        .add(CountdownAction::new(0));
+
+    assert!(ecs.get_current_action(e).is_some());
+    assert!(ecs.get_action_queue(e).len() == 1);
+
+    ecs.run();
+
+    assert!(ecs.get_current_action(e).is_some());
+    assert!(ecs.get_action_queue(e).len() == 0);
+
+    ecs.run();
+
+    assert!(ecs.get_current_action(e).is_some());
+    assert!(ecs.get_action_queue(e).len() == 0);
+
+    ecs.run();
+
+    assert!(ecs.get_current_action(e).is_none());
+}
+
+#[test]
+fn repeat_infinite() {
+    let mut ecs = Ecs::new();
+    let e = ecs.spawn_action_entity();
+
+    ecs.actions(e)
+        .config(AddConfig {
+            order: AddOrder::Back,
+            start: true,
+            repeat: Repeat::Infinite,
         })
         .add(CountdownAction::new(0));
 
@@ -411,7 +465,7 @@ fn order() {
         .config(AddConfig {
             order: AddOrder::Front,
             start: false,
-            repeat: false,
+            repeat: Repeat::Finite(0),
         })
         .add_many(
             [
@@ -439,7 +493,7 @@ fn order() {
         .config(AddConfig {
             order: AddOrder::Front,
             start: false,
-            repeat: false,
+            repeat: Repeat::Finite(0),
         })
         .add_many(
             [
@@ -482,7 +536,7 @@ fn pause_resume() {
         .config(AddConfig {
             order: AddOrder::Front,
             start: true,
-            repeat: false,
+            repeat: Repeat::Finite(0),
         })
         .add(CountdownAction::new(2));
 

--- a/src/tests.rs
+++ b/src/tests.rs
@@ -229,19 +229,19 @@ fn skip() {
         .config(AddConfig {
             order: AddOrder::Back,
             start: false,
-            repeat: Repeat::Finite(0),
+            repeat: AddRepeat::Finite(0),
         })
         .add(EmptyAction)
         .config(AddConfig {
             order: AddOrder::Back,
             start: false,
-            repeat: Repeat::Finite(1),
+            repeat: AddRepeat::Finite(1),
         })
         .add(EmptyAction)
         .config(AddConfig {
             order: AddOrder::Back,
             start: false,
-            repeat: Repeat::Infinite,
+            repeat: AddRepeat::Infinite,
         })
         .add(EmptyAction);
 
@@ -335,13 +335,13 @@ fn repeat_finite() {
         .config(AddConfig {
             order: AddOrder::Back,
             start: true,
-            repeat: Repeat::Finite(0),
+            repeat: AddRepeat::Finite(0),
         })
         .add(CountdownAction::new(0))
         .config(AddConfig {
             order: AddOrder::Back,
             start: true,
-            repeat: Repeat::Finite(1),
+            repeat: AddRepeat::Finite(1),
         })
         .add(CountdownAction::new(0));
 
@@ -372,7 +372,7 @@ fn repeat_infinite() {
         .config(AddConfig {
             order: AddOrder::Back,
             start: true,
-            repeat: Repeat::Infinite,
+            repeat: AddRepeat::Infinite,
         })
         .add(CountdownAction::new(0));
 
@@ -465,7 +465,7 @@ fn order() {
         .config(AddConfig {
             order: AddOrder::Front,
             start: false,
-            repeat: Repeat::Finite(0),
+            repeat: AddRepeat::Finite(0),
         })
         .add_many(
             [
@@ -493,7 +493,7 @@ fn order() {
         .config(AddConfig {
             order: AddOrder::Front,
             start: false,
-            repeat: Repeat::Finite(0),
+            repeat: AddRepeat::Finite(0),
         })
         .add_many(
             [
@@ -536,7 +536,7 @@ fn pause_resume() {
         .config(AddConfig {
             order: AddOrder::Front,
             start: true,
-            repeat: Repeat::Finite(0),
+            repeat: AddRepeat::Finite(0),
         })
         .add(CountdownAction::new(2));
 

--- a/src/tests.rs
+++ b/src/tests.rs
@@ -49,12 +49,12 @@ impl Ecs {
 }
 
 struct CountdownAction {
-    count: usize,
-    current: Option<usize>,
+    count: u32,
+    current: Option<u32>,
 }
 
 impl CountdownAction {
-    fn new(count: usize) -> Self {
+    fn new(count: u32) -> Self {
         Self {
             count,
             current: None,
@@ -63,7 +63,7 @@ impl CountdownAction {
 }
 
 #[derive(Component)]
-struct Countdown(usize);
+struct Countdown(u32);
 
 #[derive(Component)]
 struct Finished;
@@ -521,7 +521,7 @@ fn pause_resume() {
     let mut ecs = Ecs::new();
     let e = ecs.spawn_action_entity();
 
-    fn get_first_countdown_value(world: &mut World) -> usize {
+    fn get_first_countdown_value(world: &mut World) -> u32 {
         world.query::<&Countdown>().iter(world).next().unwrap().0
     }
 

--- a/src/tests.rs
+++ b/src/tests.rs
@@ -229,19 +229,19 @@ fn skip() {
         .config(AddConfig {
             order: AddOrder::Back,
             start: false,
-            repeat: AddRepeat::Finite(0),
+            repeat: Repeat::Amount(0),
         })
         .add(EmptyAction)
         .config(AddConfig {
             order: AddOrder::Back,
             start: false,
-            repeat: AddRepeat::Finite(1),
+            repeat: Repeat::Amount(1),
         })
         .add(EmptyAction)
         .config(AddConfig {
             order: AddOrder::Back,
             start: false,
-            repeat: AddRepeat::Infinite,
+            repeat: Repeat::Forever,
         })
         .add(EmptyAction);
 
@@ -335,13 +335,13 @@ fn repeat_finite() {
         .config(AddConfig {
             order: AddOrder::Back,
             start: true,
-            repeat: AddRepeat::Finite(0),
+            repeat: Repeat::Amount(0),
         })
         .add(CountdownAction::new(0))
         .config(AddConfig {
             order: AddOrder::Back,
             start: true,
-            repeat: AddRepeat::Finite(1),
+            repeat: Repeat::Amount(1),
         })
         .add(CountdownAction::new(0));
 
@@ -372,7 +372,7 @@ fn repeat_infinite() {
         .config(AddConfig {
             order: AddOrder::Back,
             start: true,
-            repeat: AddRepeat::Infinite,
+            repeat: Repeat::Forever,
         })
         .add(CountdownAction::new(0));
 
@@ -465,7 +465,7 @@ fn order() {
         .config(AddConfig {
             order: AddOrder::Front,
             start: false,
-            repeat: AddRepeat::Finite(0),
+            repeat: Repeat::Amount(0),
         })
         .add_many(
             [
@@ -493,7 +493,7 @@ fn order() {
         .config(AddConfig {
             order: AddOrder::Front,
             start: false,
-            repeat: AddRepeat::Finite(0),
+            repeat: Repeat::Amount(0),
         })
         .add_many(
             [
@@ -536,7 +536,7 @@ fn pause_resume() {
         .config(AddConfig {
             order: AddOrder::Front,
             start: true,
-            repeat: AddRepeat::Finite(0),
+            repeat: Repeat::Amount(0),
         })
         .add(CountdownAction::new(2));
 

--- a/src/world.rs
+++ b/src/world.rs
@@ -31,15 +31,16 @@ impl ModifyActions for EntityWorldActions<'_> {
     where
         T: IntoBoxedAction,
     {
-        let mut queue = self.world.get_mut::<ActionQueue>(self.entity).unwrap();
-        let action_tuple = (action.into_boxed(), self.config.into());
+        let cfg = self.config;
+        let mut queue = self.get_action_queue();
+        let action_tuple = (action.into_boxed(), cfg.into());
 
-        match self.config.order {
+        match cfg.order {
             AddOrder::Back => queue.push_back(action_tuple),
             AddOrder::Front => queue.push_front(action_tuple),
         }
 
-        if self.config.start && !self.has_current_action() {
+        if cfg.start && !self.has_current_action() {
             self.start_next_action();
         }
 
@@ -50,17 +51,18 @@ impl ModifyActions for EntityWorldActions<'_> {
     where
         T: BoxedActionIter,
     {
-        let mut queue = self.world.get_mut::<ActionQueue>(self.entity).unwrap();
+        let cfg = self.config;
+        let mut queue = self.get_action_queue();
 
-        match self.config.order {
+        match cfg.order {
             AddOrder::Back => {
                 for action in actions {
-                    queue.push_back((action, self.config.into()));
+                    queue.push_back((action, cfg.into()));
                 }
             }
             AddOrder::Front => {
                 for action in actions.rev() {
-                    queue.push_front((action, self.config.into()));
+                    queue.push_front((action, cfg.into()));
                 }
             }
         }
@@ -95,58 +97,30 @@ impl ModifyActions for EntityWorldActions<'_> {
     }
 
     fn skip(mut self) -> Self {
-        if let Some((action, mut cfg)) = self.pop_next_action() {
-            match &mut cfg.repeat {
-                Repeat::Finite(n) => {
-                    if *n > 0 {
-                        *n -= 1;
-                        let mut actions = self.world.get_mut::<ActionQueue>(self.entity).unwrap();
-                        actions.push_back((action, cfg));
-                    }
-                }
-                Repeat::Infinite => {
-                    let mut actions = self.world.get_mut::<ActionQueue>(self.entity).unwrap();
-                    actions.push_back((action, cfg));
-                }
-            }
+        if let Some((action, cfg)) = self.pop_next_action() {
+            self.handle_repeat(action, cfg);
         }
-
         self
     }
 
     fn clear(mut self) -> Self {
         self.stop_current_action(StopReason::Canceled);
-
-        let mut actions = self.world.get_mut::<ActionQueue>(self.entity).unwrap();
-        actions.clear();
-
+        self.get_action_queue().clear();
         self
     }
 }
 
 impl EntityWorldActions<'_> {
     fn stop_current_action(&mut self, reason: StopReason) {
-        if let Some((mut action, mut cfg)) = self.take_current_action() {
+        if let Some((mut action, cfg)) = self.take_current_action() {
             action.on_stop(self.entity, self.world, reason);
 
             match reason {
-                StopReason::Finished | StopReason::Canceled => match &mut cfg.repeat {
-                    Repeat::Finite(n) => {
-                        if *n > 0 {
-                            *n -= 1;
-                            let mut actions =
-                                self.world.get_mut::<ActionQueue>(self.entity).unwrap();
-                            actions.push_back((action, cfg));
-                        }
-                    }
-                    Repeat::Infinite => {
-                        let mut actions = self.world.get_mut::<ActionQueue>(self.entity).unwrap();
-                        actions.push_back((action, cfg));
-                    }
-                },
+                StopReason::Finished | StopReason::Canceled => {
+                    self.handle_repeat(action, cfg);
+                }
                 StopReason::Paused => {
-                    let mut actions = self.world.get_mut::<ActionQueue>(self.entity).unwrap();
-                    actions.push_front((action, cfg));
+                    self.get_action_queue().push_front((action, cfg));
                 }
             }
         }
@@ -165,6 +139,20 @@ impl EntityWorldActions<'_> {
         }
     }
 
+    fn handle_repeat(&mut self, action: BoxedAction, mut cfg: ActionConfig) {
+        match &mut cfg.repeat {
+            Repeat::Finite(n) => {
+                if *n > 0 {
+                    *n -= 1;
+                    self.get_action_queue().push_back((action, cfg));
+                }
+            }
+            Repeat::Infinite => {
+                self.get_action_queue().push_back((action, cfg));
+            }
+        }
+    }
+
     fn take_current_action(&mut self) -> Option<ActionTuple> {
         self.world
             .get_mut::<CurrentAction>(self.entity)
@@ -177,6 +165,10 @@ impl EntityWorldActions<'_> {
             .get_mut::<ActionQueue>(self.entity)
             .unwrap()
             .pop_front()
+    }
+
+    fn get_action_queue(&mut self) -> Mut<ActionQueue> {
+        self.world.get_mut::<ActionQueue>(self.entity).unwrap()
     }
 
     fn has_current_action(&self) -> bool {

--- a/src/world.rs
+++ b/src/world.rs
@@ -141,13 +141,13 @@ impl EntityWorldActions<'_> {
 
     fn handle_repeat(&mut self, action: BoxedAction, mut cfg: ActionConfig) {
         match &mut cfg.repeat {
-            Repeat::Finite(n) => {
+            AddRepeat::Finite(n) => {
                 if *n > 0 {
                     *n -= 1;
                     self.get_action_queue().push_back((action, cfg));
                 }
             }
-            Repeat::Infinite => {
+            AddRepeat::Infinite => {
                 self.get_action_queue().push_back((action, cfg));
             }
         }

--- a/src/world.rs
+++ b/src/world.rs
@@ -141,13 +141,13 @@ impl EntityWorldActions<'_> {
 
     fn handle_repeat(&mut self, action: BoxedAction, mut cfg: ActionConfig) {
         match &mut cfg.repeat {
-            AddRepeat::Finite(n) => {
+            Repeat::Amount(n) => {
                 if *n > 0 {
                     *n -= 1;
                     self.get_action_queue().push_back((action, cfg));
                 }
             }
-            AddRepeat::Infinite => {
+            Repeat::Forever => {
                 self.get_action_queue().push_back((action, cfg));
             }
         }


### PR DESCRIPTION
You can now specify how many times an action should repeat.

```rust
pub enum Repeat {
    Amount(u32),
    Forever,
}
```

A value of `Repeat::Amount(0)` means it will repeat zero times, i.e. only run once as before when the repeat bool was set to false.