### PR TITLE
Add linked actions

### DIFF
--- a/README.md
+++ b/README.md
@@ -56,9 +56,7 @@ fn setup(mut commands: Commands) {
     // as the whole collection is treated as "one action".
     commands
         .actions(agent)
-        .add_many(
-            ExecutionMode::Parallel,
-            actions![
+        .add_parallel(actions![
                 action_d,
                 action_e,
                 action_f,

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -2,7 +2,7 @@
 
 ## Version 0.7.0-dev
 
-<!-- TODO -->
+- [Add linked actions][63]
 
 ## Version 0.6.0
 
@@ -42,6 +42,7 @@
 
 First release! 🎉
 
+[63]: https://github.com/hikikones/bevy-sequential-actions/pull/63
 [55]: https://github.com/hikikones/bevy-sequential-actions/pull/55
 [53]: https://github.com/hikikones/bevy-sequential-actions/pull/53
 [52]: https://github.com/hikikones/bevy-sequential-actions/pull/52

--- a/examples/basic.rs
+++ b/examples/basic.rs
@@ -55,11 +55,11 @@ fn setup(mut commands: Commands) {
             order: AddOrder::Front,
             ..Default::default()
         })
-        .add(ActionType::Sequence(actions![
+        .add(sequential_actions![
             WaitAction::new(10.0),
             WaitAction::new(100.0),
             WaitAction::new(1000.0),
-        ]))
+        ])
         // Ain't nobody got time to wait that long, so skip'em
         .skip()
         .skip()
@@ -114,7 +114,7 @@ impl Action for MyCustomAction {
                 start: false,
                 repeat: Repeat::None,
             })
-            .add(ActionType::Sequence(actions![
+            .add(sequential_actions![
                 LerpAction::new(LerpConfig {
                     target: camera,
                     lerp_type: LerpType::Position(CAMERA_OFFSET * 0.5),
@@ -137,7 +137,7 @@ impl Action for MyCustomAction {
                     lerp_type: LerpType::Rotation(Quat::from_look(-Vec3::Z, Vec3::Y)),
                     duration: 1.0,
                 }),
-            ]))
+            ])
             .next();
     }
 

--- a/examples/basic.rs
+++ b/examples/basic.rs
@@ -55,14 +55,15 @@ fn setup(mut commands: Commands) {
             order: AddOrder::Front,
             ..Default::default()
         })
-        .add_many(
-            ExecutionMode::Sequential,
-            actions![
-                WaitAction::new(10.0),
-                WaitAction::new(100.0),
-                WaitAction::new(1000.0),
-            ],
-        )
+        // TODO
+        // .add_many(
+        //     ExecutionMode::Sequential,
+        //     actions![
+        //         WaitAction::new(10.0),
+        //         WaitAction::new(100.0),
+        //         WaitAction::new(1000.0),
+        //     ],
+        // )
         // Ain't nobody got time to wait that long, so skip'em
         .skip()
         .skip()
@@ -117,33 +118,34 @@ impl Action for MyCustomAction {
                 start: false,
                 repeat: Repeat::None,
             })
-            .add_many(
-                ExecutionMode::Sequential,
-                actions![
-                    LerpAction::new(LerpConfig {
-                        target: camera,
-                        lerp_type: LerpType::Position(CAMERA_OFFSET * 0.5),
-                        duration: 1.0,
-                    }),
-                    LerpAction::new(LerpConfig {
-                        target: agent,
-                        lerp_type: LerpType::Rotation(Quat::from_look(Vec3::Z, Vec3::Y)),
-                        duration: 1.0,
-                    }),
-                    WaitAction::new(1.0).into_boxed(),
-                    LerpAction::new(LerpConfig {
-                        target: camera,
-                        lerp_type: LerpType::Position(CAMERA_OFFSET),
-                        duration: 1.0,
-                    }),
-                    WaitAction::new(0.5).into_boxed(),
-                    LerpAction::new(LerpConfig {
-                        target: agent,
-                        lerp_type: LerpType::Rotation(Quat::from_look(-Vec3::Z, Vec3::Y)),
-                        duration: 1.0,
-                    }),
-                ],
-            )
+            // TODO
+            // .add_many(
+            //     ExecutionMode::Sequential,
+            //     actions![
+            //         LerpAction::new(LerpConfig {
+            //             target: camera,
+            //             lerp_type: LerpType::Position(CAMERA_OFFSET * 0.5),
+            //             duration: 1.0,
+            //         }),
+            //         LerpAction::new(LerpConfig {
+            //             target: agent,
+            //             lerp_type: LerpType::Rotation(Quat::from_look(Vec3::Z, Vec3::Y)),
+            //             duration: 1.0,
+            //         }),
+            //         WaitAction::new(1.0).into_boxed(),
+            //         LerpAction::new(LerpConfig {
+            //             target: camera,
+            //             lerp_type: LerpType::Position(CAMERA_OFFSET),
+            //             duration: 1.0,
+            //         }),
+            //         WaitAction::new(0.5).into_boxed(),
+            //         LerpAction::new(LerpConfig {
+            //             target: agent,
+            //             lerp_type: LerpType::Rotation(Quat::from_look(-Vec3::Z, Vec3::Y)),
+            //             duration: 1.0,
+            //         }),
+            //     ],
+            // )
             .next();
     }
 

--- a/examples/basic.rs
+++ b/examples/basic.rs
@@ -55,7 +55,7 @@ fn setup(mut commands: Commands) {
             order: AddOrder::Front,
             ..Default::default()
         })
-        .add(ActionKind::Sequence(actions![
+        .add(ActionType::Sequence(actions![
             WaitAction::new(10.0),
             WaitAction::new(100.0),
             WaitAction::new(1000.0),
@@ -114,7 +114,7 @@ impl Action for MyCustomAction {
                 start: false,
                 repeat: Repeat::None,
             })
-            .add(ActionKind::Sequence(actions![
+            .add(ActionType::Sequence(actions![
                 LerpAction::new(LerpConfig {
                     target: camera,
                     lerp_type: LerpType::Position(CAMERA_OFFSET * 0.5),

--- a/examples/basic.rs
+++ b/examples/basic.rs
@@ -55,15 +55,11 @@ fn setup(mut commands: Commands) {
             order: AddOrder::Front,
             ..Default::default()
         })
-        // TODO
-        // .add_many(
-        //     ExecutionMode::Sequential,
-        //     actions![
-        //         WaitAction::new(10.0),
-        //         WaitAction::new(100.0),
-        //         WaitAction::new(1000.0),
-        //     ],
-        // )
+        .add(ActionKind::Sequence(actions![
+            WaitAction::new(10.0),
+            WaitAction::new(100.0),
+            WaitAction::new(1000.0),
+        ]))
         // Ain't nobody got time to wait that long, so skip'em
         .skip()
         .skip()
@@ -118,34 +114,30 @@ impl Action for MyCustomAction {
                 start: false,
                 repeat: Repeat::None,
             })
-            // TODO
-            // .add_many(
-            //     ExecutionMode::Sequential,
-            //     actions![
-            //         LerpAction::new(LerpConfig {
-            //             target: camera,
-            //             lerp_type: LerpType::Position(CAMERA_OFFSET * 0.5),
-            //             duration: 1.0,
-            //         }),
-            //         LerpAction::new(LerpConfig {
-            //             target: agent,
-            //             lerp_type: LerpType::Rotation(Quat::from_look(Vec3::Z, Vec3::Y)),
-            //             duration: 1.0,
-            //         }),
-            //         WaitAction::new(1.0).into_boxed(),
-            //         LerpAction::new(LerpConfig {
-            //             target: camera,
-            //             lerp_type: LerpType::Position(CAMERA_OFFSET),
-            //             duration: 1.0,
-            //         }),
-            //         WaitAction::new(0.5).into_boxed(),
-            //         LerpAction::new(LerpConfig {
-            //             target: agent,
-            //             lerp_type: LerpType::Rotation(Quat::from_look(-Vec3::Z, Vec3::Y)),
-            //             duration: 1.0,
-            //         }),
-            //     ],
-            // )
+            .add(ActionKind::Sequence(actions![
+                LerpAction::new(LerpConfig {
+                    target: camera,
+                    lerp_type: LerpType::Position(CAMERA_OFFSET * 0.5),
+                    duration: 1.0,
+                }),
+                LerpAction::new(LerpConfig {
+                    target: agent,
+                    lerp_type: LerpType::Rotation(Quat::from_look(Vec3::Z, Vec3::Y)),
+                    duration: 1.0,
+                }),
+                WaitAction::new(1.0).into_boxed(),
+                LerpAction::new(LerpConfig {
+                    target: camera,
+                    lerp_type: LerpType::Position(CAMERA_OFFSET),
+                    duration: 1.0,
+                }),
+                WaitAction::new(0.5).into_boxed(),
+                LerpAction::new(LerpConfig {
+                    target: agent,
+                    lerp_type: LerpType::Rotation(Quat::from_look(-Vec3::Z, Vec3::Y)),
+                    duration: 1.0,
+                }),
+            ]))
             .next();
     }
 

--- a/examples/basic.rs
+++ b/examples/basic.rs
@@ -55,7 +55,7 @@ fn setup(mut commands: Commands) {
             order: AddOrder::Front,
             ..Default::default()
         })
-        .add(sequential_actions![
+        .add_sequence(actions![
             WaitAction::new(10.0),
             WaitAction::new(100.0),
             WaitAction::new(1000.0),
@@ -114,7 +114,7 @@ impl Action for MyCustomAction {
                 start: false,
                 repeat: Repeat::None,
             })
-            .add(sequential_actions![
+            .add_sequence(actions![
                 LerpAction::new(LerpConfig {
                     target: camera,
                     lerp_type: LerpType::Position(CAMERA_OFFSET * 0.5),

--- a/examples/parallel.rs
+++ b/examples/parallel.rs
@@ -24,7 +24,7 @@ fn setup(mut commands: Commands, camera_q: Query<Entity, With<CameraPivot>>) {
             repeat: Repeat::Forever,
         })
         .add(WaitAction::new(1.0))
-        .add(ActionType::Parallel(actions![
+        .add(parallel_actions![
             MoveAction::new(MoveConfig {
                 target: Vec3::X * 3.0,
                 speed: Random::new(0.5, 5.0),
@@ -46,9 +46,9 @@ fn setup(mut commands: Commands, camera_q: Query<Entity, With<CameraPivot>>) {
                     .unwrap()
                     .confirm_and_persist();
             }
-        ]))
+        ])
         .add(WaitAction::new(1.0))
-        .add(ActionType::Parallel(actions![
+        .add(parallel_actions![
             MoveAction::new(MoveConfig {
                 target: -Vec3::X * 3.0,
                 speed: Random::new(0.5, 5.0),
@@ -75,5 +75,5 @@ fn setup(mut commands: Commands, camera_q: Query<Entity, With<CameraPivot>>) {
                     println!("on_stop");
                 }
             )
-        ]));
+        ]);
 }

--- a/examples/parallel.rs
+++ b/examples/parallel.rs
@@ -24,7 +24,7 @@ fn setup(mut commands: Commands, camera_q: Query<Entity, With<CameraPivot>>) {
             repeat: Repeat::Forever,
         })
         .add(WaitAction::new(1.0))
-        .add(ActionKind::Parallel(actions![
+        .add(ActionType::Parallel(actions![
             MoveAction::new(MoveConfig {
                 target: Vec3::X * 3.0,
                 speed: Random::new(0.5, 5.0),
@@ -48,7 +48,7 @@ fn setup(mut commands: Commands, camera_q: Query<Entity, With<CameraPivot>>) {
             }
         ]))
         .add(WaitAction::new(1.0))
-        .add(ActionKind::Parallel(actions![
+        .add(ActionType::Parallel(actions![
             MoveAction::new(MoveConfig {
                 target: -Vec3::X * 3.0,
                 speed: Random::new(0.5, 5.0),

--- a/examples/parallel.rs
+++ b/examples/parallel.rs
@@ -24,64 +24,56 @@ fn setup(mut commands: Commands, camera_q: Query<Entity, With<CameraPivot>>) {
             repeat: Repeat::Forever,
         })
         .add(WaitAction::new(1.0))
-        // TODO
-        // .add_many(
-        //     ExecutionMode::Parallel,
-        //     actions![
-        //         MoveAction::new(MoveConfig {
-        //             target: Vec3::X * 3.0,
-        //             speed: Random::new(0.5, 5.0),
-        //             rotate: false,
-        //         }),
-        //         RotateAction::new(RotateConfig {
-        //             target: RotateType::Look(Vec3::X),
-        //             speed: Random::new(std::f32::consts::FRAC_PI_8, std::f32::consts::PI),
-        //         }),
-        //         LerpAction::new(LerpConfig {
-        //             target: camera_pivot,
-        //             lerp_type: LerpType::Rotation(Quat::from_look(-Vec3::X, Vec3::Y)),
-        //             duration: Random::new(2.0, 6.0),
-        //         }),
-        //         |agent: Entity, world: &mut World, _commands: &mut ActionCommands| {
-        //             println!("on_start");
-        //             world
-        //                 .get_mut::<ActionFinished>(agent)
-        //                 .unwrap()
-        //                 .confirm_and_persist();
-        //         }
-        //     ],
-        // )
-        .add(WaitAction::new(1.0));
-    // TODO
-    // .add_many(
-    //     ExecutionMode::Parallel,
-    //     actions![
-    //         MoveAction::new(MoveConfig {
-    //             target: -Vec3::X * 3.0,
-    //             speed: Random::new(0.5, 5.0),
-    //             rotate: false,
-    //         }),
-    //         RotateAction::new(RotateConfig {
-    //             target: RotateType::Look(-Vec3::X),
-    //             speed: Random::new(std::f32::consts::FRAC_PI_8, std::f32::consts::PI),
-    //         }),
-    //         LerpAction::new(LerpConfig {
-    //             target: camera_pivot,
-    //             lerp_type: LerpType::Rotation(Quat::from_look(Vec3::X, Vec3::Y)),
-    //             duration: Random::new(2.0, 6.0),
-    //         }),
-    //         (
-    //             |agent: Entity, world: &mut World, _commands: &mut ActionCommands| {
-    //                 println!("on_start and... ");
-    //                 world
-    //                     .get_mut::<ActionFinished>(agent)
-    //                     .unwrap()
-    //                     .confirm_and_persist();
-    //             },
-    //             |_agent: Entity, _world: &mut World, _reason: StopReason| {
-    //                 println!("on_stop");
-    //             }
-    //         )
-    //     ],
-    // );
+        .add(ActionKind::Parallel(actions![
+            MoveAction::new(MoveConfig {
+                target: Vec3::X * 3.0,
+                speed: Random::new(0.5, 5.0),
+                rotate: false,
+            }),
+            RotateAction::new(RotateConfig {
+                target: RotateType::Look(Vec3::X),
+                speed: Random::new(std::f32::consts::FRAC_PI_8, std::f32::consts::PI),
+            }),
+            LerpAction::new(LerpConfig {
+                target: camera_pivot,
+                lerp_type: LerpType::Rotation(Quat::from_look(-Vec3::X, Vec3::Y)),
+                duration: Random::new(2.0, 6.0),
+            }),
+            |agent: Entity, world: &mut World, _commands: &mut ActionCommands| {
+                println!("on_start");
+                world
+                    .get_mut::<ActionFinished>(agent)
+                    .unwrap()
+                    .confirm_and_persist();
+            }
+        ]))
+        .add(WaitAction::new(1.0))
+        .add(ActionKind::Parallel(actions![
+            MoveAction::new(MoveConfig {
+                target: -Vec3::X * 3.0,
+                speed: Random::new(0.5, 5.0),
+                rotate: false,
+            }),
+            RotateAction::new(RotateConfig {
+                target: RotateType::Look(-Vec3::X),
+                speed: Random::new(std::f32::consts::FRAC_PI_8, std::f32::consts::PI),
+            }),
+            LerpAction::new(LerpConfig {
+                target: camera_pivot,
+                lerp_type: LerpType::Rotation(Quat::from_look(Vec3::X, Vec3::Y)),
+                duration: Random::new(2.0, 6.0),
+            }),
+            (
+                |agent: Entity, world: &mut World, _commands: &mut ActionCommands| {
+                    println!("on_start and... ");
+                    world
+                        .get_mut::<ActionFinished>(agent)
+                        .unwrap()
+                        .confirm_and_persist();
+                },
+                |_agent: Entity, _world: &mut World, _reason: StopReason| {
+                    println!("on_stop");
+                }
+            )
+        ]));
 }

--- a/examples/parallel.rs
+++ b/examples/parallel.rs
@@ -24,7 +24,7 @@ fn setup(mut commands: Commands, camera_q: Query<Entity, With<CameraPivot>>) {
             repeat: Repeat::Forever,
         })
         .add(WaitAction::new(1.0))
-        .add(parallel_actions![
+        .add_parallel(actions![
             MoveAction::new(MoveConfig {
                 target: Vec3::X * 3.0,
                 speed: Random::new(0.5, 5.0),
@@ -48,7 +48,7 @@ fn setup(mut commands: Commands, camera_q: Query<Entity, With<CameraPivot>>) {
             }
         ])
         .add(WaitAction::new(1.0))
-        .add(parallel_actions![
+        .add_parallel(actions![
             MoveAction::new(MoveConfig {
                 target: -Vec3::X * 3.0,
                 speed: Random::new(0.5, 5.0),

--- a/examples/parallel.rs
+++ b/examples/parallel.rs
@@ -24,62 +24,64 @@ fn setup(mut commands: Commands, camera_q: Query<Entity, With<CameraPivot>>) {
             repeat: Repeat::Forever,
         })
         .add(WaitAction::new(1.0))
-        .add_many(
-            ExecutionMode::Parallel,
-            actions![
-                MoveAction::new(MoveConfig {
-                    target: Vec3::X * 3.0,
-                    speed: Random::new(0.5, 5.0),
-                    rotate: false,
-                }),
-                RotateAction::new(RotateConfig {
-                    target: RotateType::Look(Vec3::X),
-                    speed: Random::new(std::f32::consts::FRAC_PI_8, std::f32::consts::PI),
-                }),
-                LerpAction::new(LerpConfig {
-                    target: camera_pivot,
-                    lerp_type: LerpType::Rotation(Quat::from_look(-Vec3::X, Vec3::Y)),
-                    duration: Random::new(2.0, 6.0),
-                }),
-                |agent: Entity, world: &mut World, _commands: &mut ActionCommands| {
-                    println!("on_start");
-                    world
-                        .get_mut::<ActionFinished>(agent)
-                        .unwrap()
-                        .confirm_and_persist();
-                }
-            ],
-        )
-        .add(WaitAction::new(1.0))
-        .add_many(
-            ExecutionMode::Parallel,
-            actions![
-                MoveAction::new(MoveConfig {
-                    target: -Vec3::X * 3.0,
-                    speed: Random::new(0.5, 5.0),
-                    rotate: false,
-                }),
-                RotateAction::new(RotateConfig {
-                    target: RotateType::Look(-Vec3::X),
-                    speed: Random::new(std::f32::consts::FRAC_PI_8, std::f32::consts::PI),
-                }),
-                LerpAction::new(LerpConfig {
-                    target: camera_pivot,
-                    lerp_type: LerpType::Rotation(Quat::from_look(Vec3::X, Vec3::Y)),
-                    duration: Random::new(2.0, 6.0),
-                }),
-                (
-                    |agent: Entity, world: &mut World, _commands: &mut ActionCommands| {
-                        println!("on_start and... ");
-                        world
-                            .get_mut::<ActionFinished>(agent)
-                            .unwrap()
-                            .confirm_and_persist();
-                    },
-                    |_agent: Entity, _world: &mut World, _reason: StopReason| {
-                        println!("on_stop");
-                    }
-                )
-            ],
-        );
+        // TODO
+        // .add_many(
+        //     ExecutionMode::Parallel,
+        //     actions![
+        //         MoveAction::new(MoveConfig {
+        //             target: Vec3::X * 3.0,
+        //             speed: Random::new(0.5, 5.0),
+        //             rotate: false,
+        //         }),
+        //         RotateAction::new(RotateConfig {
+        //             target: RotateType::Look(Vec3::X),
+        //             speed: Random::new(std::f32::consts::FRAC_PI_8, std::f32::consts::PI),
+        //         }),
+        //         LerpAction::new(LerpConfig {
+        //             target: camera_pivot,
+        //             lerp_type: LerpType::Rotation(Quat::from_look(-Vec3::X, Vec3::Y)),
+        //             duration: Random::new(2.0, 6.0),
+        //         }),
+        //         |agent: Entity, world: &mut World, _commands: &mut ActionCommands| {
+        //             println!("on_start");
+        //             world
+        //                 .get_mut::<ActionFinished>(agent)
+        //                 .unwrap()
+        //                 .confirm_and_persist();
+        //         }
+        //     ],
+        // )
+        .add(WaitAction::new(1.0));
+    // TODO
+    // .add_many(
+    //     ExecutionMode::Parallel,
+    //     actions![
+    //         MoveAction::new(MoveConfig {
+    //             target: -Vec3::X * 3.0,
+    //             speed: Random::new(0.5, 5.0),
+    //             rotate: false,
+    //         }),
+    //         RotateAction::new(RotateConfig {
+    //             target: RotateType::Look(-Vec3::X),
+    //             speed: Random::new(std::f32::consts::FRAC_PI_8, std::f32::consts::PI),
+    //         }),
+    //         LerpAction::new(LerpConfig {
+    //             target: camera_pivot,
+    //             lerp_type: LerpType::Rotation(Quat::from_look(Vec3::X, Vec3::Y)),
+    //             duration: Random::new(2.0, 6.0),
+    //         }),
+    //         (
+    //             |agent: Entity, world: &mut World, _commands: &mut ActionCommands| {
+    //                 println!("on_start and... ");
+    //                 world
+    //                     .get_mut::<ActionFinished>(agent)
+    //                     .unwrap()
+    //                     .confirm_and_persist();
+    //             },
+    //             |_agent: Entity, _world: &mut World, _reason: StopReason| {
+    //                 println!("on_stop");
+    //             }
+    //         )
+    //     ],
+    // );
 }

--- a/src/action_commands.rs
+++ b/src/action_commands.rs
@@ -58,7 +58,7 @@ impl ModifyActions for AgentActions<'_> {
         self
     }
 
-    fn add(&mut self, action: impl Into<ActionKind>) -> &mut Self {
+    fn add(&mut self, action: impl Into<ActionType>) -> &mut Self {
         let agent = self.agent;
         let config = self.config;
         let action = action.into();

--- a/src/action_commands.rs
+++ b/src/action_commands.rs
@@ -58,9 +58,10 @@ impl ModifyActions for AgentActions<'_> {
         self
     }
 
-    fn add(&mut self, action: impl IntoBoxedAction) -> &mut Self {
+    fn add(&mut self, action: impl Into<ActionKind>) -> &mut Self {
         let agent = self.agent;
         let config = self.config;
+        let action = action.into();
         self.commands.push(move |world| {
             world.add_action(agent, config, action);
         });

--- a/src/action_commands.rs
+++ b/src/action_commands.rs
@@ -68,6 +68,10 @@ impl ModifyActions for AgentActions<'_> {
         self
     }
 
+    fn add_linked(&mut self, builder: impl FnOnce(&mut LinkedActionsBuilder)) -> &mut Self {
+        todo!()
+    }
+
     fn next(&mut self) -> &mut Self {
         let agent = self.agent;
         self.commands.push(move |world| {

--- a/src/action_commands.rs
+++ b/src/action_commands.rs
@@ -68,15 +68,6 @@ impl ModifyActions for AgentActions<'_> {
         self
     }
 
-    fn add_many(&mut self, mode: ExecutionMode, actions: impl BoxedActionIter) -> &mut Self {
-        let agent = self.agent;
-        let config = self.config;
-        self.commands.push(move |world| {
-            world.add_actions(agent, config, mode, actions);
-        });
-        self
-    }
-
     fn next(&mut self) -> &mut Self {
         let agent = self.agent;
         self.commands.push(move |world| {

--- a/src/commands.rs
+++ b/src/commands.rs
@@ -25,9 +25,10 @@ impl ModifyActions for AgentCommandsActions<'_, '_, '_> {
         self
     }
 
-    fn add(&mut self, action: impl IntoBoxedAction) -> &mut Self {
+    fn add(&mut self, action: impl Into<ActionKind>) -> &mut Self {
         let agent = self.agent;
         let config = self.config;
+        let action = action.into();
         self.commands.add(move |world: &mut World| {
             world.add_action(agent, config, action);
         });

--- a/src/commands.rs
+++ b/src/commands.rs
@@ -35,6 +35,10 @@ impl ModifyActions for AgentCommandsActions<'_, '_, '_> {
         self
     }
 
+    fn add_linked(&mut self, builder: impl FnOnce(&mut LinkedActionsBuilder)) -> &mut Self {
+        todo!()
+    }
+
     fn next(&mut self) -> &mut Self {
         let agent = self.agent;
         self.commands.add(move |world: &mut World| {

--- a/src/commands.rs
+++ b/src/commands.rs
@@ -25,10 +25,9 @@ impl ModifyActions for AgentCommandsActions<'_, '_, '_> {
         self
     }
 
-    fn add(&mut self, action: impl Into<ActionType>) -> &mut Self {
+    fn add(&mut self, action: impl IntoBoxedAction) -> &mut Self {
         let agent = self.agent;
         let config = self.config;
-        let action = action.into();
 
         self.commands.add(move |world: &mut World| {
             world.add_action(agent, config, action);
@@ -37,15 +36,43 @@ impl ModifyActions for AgentCommandsActions<'_, '_, '_> {
         self
     }
 
-    fn add_linked(&mut self, f: impl FnOnce(&mut LinkedActionsBuilder)) -> &mut Self {
+    fn add_sequence(
+        &mut self,
+        actions: impl DoubleEndedIterator<Item = BoxedAction> + Send + Sync + 'static,
+    ) -> &mut Self {
         let agent = self.agent;
         let config = self.config;
 
-        let mut actions = LinkedActionsBuilder::new();
-        f(&mut actions);
+        self.commands.add(move |world: &mut World| {
+            world.add_actions(agent, config, actions);
+        });
+
+        self
+    }
+
+    fn add_parallel(
+        &mut self,
+        actions: impl Iterator<Item = BoxedAction> + Send + Sync + 'static,
+    ) -> &mut Self {
+        let agent = self.agent;
+        let config = self.config;
 
         self.commands.add(move |world: &mut World| {
-            world.add_linked_actions(agent, config, actions);
+            world.add_parallel_actions(agent, config, actions);
+        });
+
+        self
+    }
+
+    fn add_linked(
+        &mut self,
+        f: impl FnOnce(&mut LinkedActionsBuilder) + Send + Sync + 'static,
+    ) -> &mut Self {
+        let agent = self.agent;
+        let config = self.config;
+
+        self.commands.add(move |world: &mut World| {
+            world.add_linked_actions(agent, config, f);
         });
 
         self

--- a/src/commands.rs
+++ b/src/commands.rs
@@ -29,53 +29,75 @@ impl ModifyActions for AgentCommandsActions<'_, '_, '_> {
         let agent = self.agent;
         let config = self.config;
         let action = action.into();
+
         self.commands.add(move |world: &mut World| {
             world.add_action(agent, config, action);
         });
+
         self
     }
 
-    fn add_linked(&mut self, builder: impl FnOnce(&mut LinkedActionsBuilder)) -> &mut Self {
-        todo!()
+    fn add_linked(&mut self, f: impl FnOnce(&mut LinkedActionsBuilder)) -> &mut Self {
+        let agent = self.agent;
+        let config = self.config;
+
+        let mut actions = LinkedActionsBuilder::new();
+        f(&mut actions);
+
+        self.commands.add(move |world: &mut World| {
+            world.add_linked_actions(agent, config, actions);
+        });
+
+        self
     }
 
     fn next(&mut self) -> &mut Self {
         let agent = self.agent;
+
         self.commands.add(move |world: &mut World| {
             world.next_action(agent);
         });
+
         self
     }
 
     fn cancel(&mut self) -> &mut Self {
         let agent = self.agent;
+
         self.commands.add(move |world: &mut World| {
             world.cancel_action(agent);
         });
+
         self
     }
 
     fn pause(&mut self) -> &mut Self {
         let agent = self.agent;
+
         self.commands.add(move |world: &mut World| {
             world.pause_action(agent);
         });
+
         self
     }
 
     fn skip(&mut self) -> &mut Self {
         let agent = self.agent;
+
         self.commands.add(move |world: &mut World| {
             world.skip_action(agent);
         });
+
         self
     }
 
     fn clear(&mut self) -> &mut Self {
         let agent = self.agent;
+
         self.commands.add(move |world: &mut World| {
             world.clear_actions(agent);
         });
+
         self
     }
 }

--- a/src/commands.rs
+++ b/src/commands.rs
@@ -35,15 +35,6 @@ impl ModifyActions for AgentCommandsActions<'_, '_, '_> {
         self
     }
 
-    fn add_many(&mut self, mode: ExecutionMode, actions: impl BoxedActionIter) -> &mut Self {
-        let agent = self.agent;
-        let config = self.config;
-        self.commands.add(move |world: &mut World| {
-            world.add_actions(agent, config, mode, actions);
-        });
-        self
-    }
-
     fn next(&mut self) -> &mut Self {
         let agent = self.agent;
         self.commands.add(move |world: &mut World| {

--- a/src/commands.rs
+++ b/src/commands.rs
@@ -25,7 +25,7 @@ impl ModifyActions for AgentCommandsActions<'_, '_, '_> {
         self
     }
 
-    fn add(&mut self, action: impl Into<ActionKind>) -> &mut Self {
+    fn add(&mut self, action: impl Into<ActionType>) -> &mut Self {
         let agent = self.agent;
         let config = self.config;
         let action = action.into();

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -401,6 +401,7 @@ impl Action for EmptyAction {
 
 fn test() {
     add_action(EmptyAction);
+    add_action(ActionType::Single(Box::new(EmptyAction)));
 }
 
 impl From<BoxedAction> for ActionType {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -345,7 +345,7 @@ pub type BoxedAction = Box<dyn Action>;
 pub enum ActionKind {
     Single(BoxedAction),
     Sequence(Box<dyn DoubleEndedIterator<Item = BoxedAction> + Send + Sync>),
-    Parallel(Box<[BoxedAction]>),
+    Parallel(Box<dyn Iterator<Item = BoxedAction> + Send + Sync>),
     Linked(Box<[Box<[BoxedAction]>]>),
 }
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -200,8 +200,8 @@ mod plugin;
 mod traits;
 mod world;
 
-// #[cfg(test)]
-// mod tests;
+#[cfg(test)]
+mod tests;
 
 pub use action_commands::*;
 pub use commands::*;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -363,6 +363,32 @@ impl From<BoxedAction> for ActionType {
     }
 }
 
+pub struct LinkedActionsBuilder(Vec<OneOrMany>);
+
+impl LinkedActionsBuilder {
+    pub fn add(&mut self, action: impl IntoBoxedAction) -> &mut Self {
+        self.0.push(OneOrMany::One(action.into_boxed()));
+        self
+    }
+
+    pub fn add_sequence(&mut self, actions: impl Iterator<Item = BoxedAction>) -> &mut Self {
+        for action in actions.into_iter() {
+            self.0.push(OneOrMany::One(action.into_boxed()));
+        }
+        self
+    }
+
+    pub fn add_parallel(&mut self, actions: impl Iterator<Item = BoxedAction>) -> &mut Self {
+        self.0.push(OneOrMany::Many(actions.collect()));
+        self
+    }
+}
+
+enum OneOrMany {
+    One(BoxedAction),
+    Many(Box<[BoxedAction]>),
+}
+
 enum ActionTypeInternal {
     One(BoxedAction),
     Many(Box<[BoxedAction]>),

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -200,8 +200,8 @@ mod plugin;
 mod traits;
 mod world;
 
-#[cfg(test)]
-mod tests;
+// #[cfg(test)]
+// mod tests;
 
 pub use action_commands::*;
 pub use commands::*;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -369,6 +369,16 @@ enum ActionTypeInternal {
     Linked(Box<[Box<[BoxedAction]>]>, usize),
 }
 
+impl ActionTypeInternal {
+    fn len(&self) -> u32 {
+        match self {
+            ActionTypeInternal::One(_) => 1,
+            ActionTypeInternal::Many(actions) => actions.len() as u32,
+            ActionTypeInternal::Linked(actions, index) => actions[*index].len() as u32,
+        }
+    }
+}
+
 type ActionTuple = (ActionTypeInternal, Repeat);
 
 #[derive(Default, Component)]

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -363,13 +363,13 @@ impl From<BoxedAction> for ActionType {
     }
 }
 
-enum InternalActionType {
-    Single(BoxedAction),
-    Parallel(Box<[BoxedAction]>),
+enum ActionTypeInternal {
+    One(BoxedAction),
+    Many(Box<[BoxedAction]>),
     Linked(Box<[Box<[BoxedAction]>]>, usize),
 }
 
-type ActionTuple = (InternalActionType, Repeat);
+type ActionTuple = (ActionTypeInternal, Repeat);
 
 #[derive(Default, Component)]
 struct ActionQueue(VecDeque<ActionTuple>);

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -188,7 +188,6 @@ impl<T: StateData> Action for SetStateAction<T> {
 use std::{
     collections::VecDeque,
     ops::{Deref, DerefMut},
-    slice::IterMut,
 };
 
 use bevy_ecs::prelude::*;
@@ -403,40 +402,5 @@ impl DerefMut for ActionQueue {
 impl DerefMut for CurrentAction {
     fn deref_mut(&mut self) -> &mut Self::Target {
         &mut self.0
-    }
-}
-
-fn add_action(action: impl Into<ActionType>) {
-    // todo
-}
-
-struct EmptyAction;
-impl Action for EmptyAction {
-    fn on_start(&mut self, agent: Entity, world: &mut World, commands: &mut ActionCommands) {
-        todo!()
-    }
-
-    fn on_stop(&mut self, agent: Entity, world: &mut World, reason: StopReason) {
-        todo!()
-    }
-}
-
-fn test() {
-    add_action(EmptyAction);
-    add_action(ActionType::Single(Box::new(EmptyAction)));
-}
-
-impl From<BoxedAction> for ActionType {
-    fn from(action: BoxedAction) -> Self {
-        Self::Single(action)
-    }
-}
-
-impl<T> From<T> for ActionType
-where
-    T: Action,
-{
-    fn from(action: T) -> Self {
-        Self::Single(action.into_boxed())
     }
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -69,7 +69,7 @@ fn setup(mut commands: Commands) {
     // as the whole collection is treated as "one action".
     commands
         .actions(agent)
-        .add_sequence(actions![
+        .add_parallel(actions![
                 action_d,
                 action_e,
                 action_f,

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -199,8 +199,8 @@ mod plugin;
 mod traits;
 mod world;
 
-#[cfg(test)]
-mod tests;
+// #[cfg(test)]
+// mod tests;
 
 pub use action_commands::*;
 pub use commands::*;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -342,6 +342,28 @@ pub enum ExecutionMode {
 /// A boxed [`Action`].
 pub type BoxedAction = Box<dyn Action>;
 
+pub enum ActionKind {
+    Single(BoxedAction),
+    Sequence(Box<dyn DoubleEndedIterator<Item = BoxedAction> + Send + Sync>),
+    Parallel(Box<[BoxedAction]>),
+    Linked(Box<[Box<[BoxedAction]>]>),
+}
+
+impl<T> From<T> for ActionKind
+where
+    T: Action,
+{
+    fn from(action: T) -> Self {
+        Self::Single(action.into_boxed())
+    }
+}
+
+impl From<BoxedAction> for ActionKind {
+    fn from(action: BoxedAction) -> Self {
+        Self::Single(action)
+    }
+}
+
 type ActionTuple = (ActionType, Repeat);
 
 #[derive(Default, Component)]

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -366,6 +366,14 @@ impl From<BoxedAction> for ActionType {
 pub struct LinkedActionsBuilder(Vec<OneOrMany>);
 
 impl LinkedActionsBuilder {
+    const fn new() -> Self {
+        Self(Vec::new())
+    }
+
+    fn build(self) -> ActionTypeInternal_temp {
+        todo!()
+    }
+
     pub fn add(&mut self, action: impl IntoBoxedAction) -> &mut Self {
         self.0.push(OneOrMany::One(action.into_boxed()));
         self
@@ -387,6 +395,12 @@ impl LinkedActionsBuilder {
 enum OneOrMany {
     One(BoxedAction),
     Many(Box<[BoxedAction]>),
+}
+
+enum ActionTypeInternal_temp {
+    One(BoxedAction),
+    Many(Box<[BoxedAction]>),
+    Linked(Box<[OneOrMany]>, usize),
 }
 
 enum ActionTypeInternal {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -69,9 +69,7 @@ fn setup(mut commands: Commands) {
     // as the whole collection is treated as "one action".
     commands
         .actions(agent)
-        .add_many(
-            ExecutionMode::Parallel,
-            actions![
+        .add_sequence(actions![
                 action_d,
                 action_e,
                 action_f,
@@ -332,6 +330,7 @@ pub enum StopReason {
 /// A boxed [`Action`].
 pub type BoxedAction = Box<dyn Action>;
 
+/// Builder for linked actions.
 pub struct LinkedActionsBuilder(Vec<OneOrMany>);
 
 impl LinkedActionsBuilder {
@@ -343,11 +342,13 @@ impl LinkedActionsBuilder {
         self.0.into_boxed_slice()
     }
 
+    /// Add a single [`action`](Action).
     pub fn add(&mut self, action: impl IntoBoxedAction) -> &mut Self {
         self.0.push(OneOrMany::One(action.into_boxed()));
         self
     }
 
+    /// Add a collection of sequential actions.
     pub fn add_sequence(&mut self, actions: impl Iterator<Item = BoxedAction>) -> &mut Self {
         for action in actions.into_iter() {
             self.0.push(OneOrMany::One(action));
@@ -355,6 +356,7 @@ impl LinkedActionsBuilder {
         self
     }
 
+    /// Add a collection of parallel actions.
     pub fn add_parallel(&mut self, actions: impl Iterator<Item = BoxedAction>) -> &mut Self {
         let actions = actions.collect::<Box<[_]>>();
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -374,6 +374,15 @@ type ActionTuple = (InternalActionType, Repeat);
 #[derive(Default, Component)]
 struct ActionQueue(VecDeque<ActionTuple>);
 
+impl ActionQueue {
+    fn push(&mut self, order: AddOrder, action: ActionTuple) {
+        match order {
+            AddOrder::Back => self.0.push_back(action),
+            AddOrder::Front => self.0.push_front(action),
+        }
+    }
+}
+
 #[derive(Default, Component)]
 struct CurrentAction(Option<ActionTuple>);
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -336,6 +336,7 @@ pub enum ExecutionMode {
     Sequential,
     /// Execute the [`actions`](Action) in parallel, i.e. all at once.
     Parallel,
+    Linked,
 }
 
 /// A boxed [`Action`].
@@ -350,24 +351,9 @@ struct ActionQueue(VecDeque<ActionTuple>);
 struct CurrentAction(Option<ActionTuple>);
 
 enum ActionType {
-    One([BoxedAction; 1]),
-    Many(Box<[BoxedAction]>),
-}
-
-impl ActionType {
-    fn iter_mut(&mut self) -> IterMut<BoxedAction> {
-        match self {
-            ActionType::One(a) => a.iter_mut(),
-            ActionType::Many(a) => a.iter_mut(),
-        }
-    }
-
-    fn len(&self) -> u32 {
-        match self {
-            ActionType::One(_) => 1,
-            ActionType::Many(a) => a.len() as u32,
-        }
-    }
+    Single(BoxedAction),
+    Parallel(Box<[BoxedAction]>),
+    Linked(Box<[BoxedAction]>, usize),
 }
 
 impl Deref for ActionQueue {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -345,7 +345,7 @@ pub enum ActionType {
     Single(BoxedAction),
     Sequence(Box<dyn DoubleEndedIterator<Item = BoxedAction> + Send + Sync>),
     Parallel(Box<dyn Iterator<Item = BoxedAction> + Send + Sync>),
-    Linked(Box<[Box<[BoxedAction]>]>),
+    Linked(Box<dyn Iterator<Item = Box<[BoxedAction]>> + Send + Sync>),
 }
 
 impl<T> From<T> for ActionType

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -375,7 +375,7 @@ struct CurrentAction(Option<ActionTuple>);
 enum ActionType {
     Single(BoxedAction),
     Parallel(Box<[BoxedAction]>),
-    Linked(Box<[BoxedAction]>, usize),
+    Linked(Box<[Box<[BoxedAction]>]>, usize),
 }
 
 impl Deref for ActionQueue {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -350,7 +350,7 @@ impl LinkedActionsBuilder {
 
     /// Add a collection of sequential actions.
     pub fn add_sequence(&mut self, actions: impl Iterator<Item = BoxedAction>) -> &mut Self {
-        for action in actions.into_iter() {
+        for action in actions {
             self.0.push(OneOrMany::One(action));
         }
         self

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -383,3 +383,37 @@ impl DerefMut for CurrentAction {
         &mut self.0
     }
 }
+
+fn add_action(action: impl Into<ActionType>) {
+    // todo
+}
+
+struct EmptyAction;
+impl Action for EmptyAction {
+    fn on_start(&mut self, agent: Entity, world: &mut World, commands: &mut ActionCommands) {
+        todo!()
+    }
+
+    fn on_stop(&mut self, agent: Entity, world: &mut World, reason: StopReason) {
+        todo!()
+    }
+}
+
+fn test() {
+    add_action(EmptyAction);
+}
+
+impl From<BoxedAction> for ActionType {
+    fn from(action: BoxedAction) -> Self {
+        Self::Single(action)
+    }
+}
+
+impl<T> From<T> for ActionType
+where
+    T: Action,
+{
+    fn from(action: T) -> Self {
+        Self::Single(action.into_boxed())
+    }
+}

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -199,8 +199,8 @@ mod plugin;
 mod traits;
 mod world;
 
-// #[cfg(test)]
-// mod tests;
+#[cfg(test)]
+mod tests;
 
 pub use action_commands::*;
 pub use commands::*;

--- a/src/macros.rs
+++ b/src/macros.rs
@@ -18,35 +18,35 @@ use crate::{Action, BoxedAction};
 /// ```
 #[macro_export]
 macro_rules! actions {
-    ( $( $x:expr ),* $(,)? ) => {
-        [ $( $crate::IntoBoxedAction::into_boxed($x) ),* ]
+    ( $( $action:expr ),* $(,)? ) => {
+        [ $( $crate::IntoBoxedAction::into_boxed($action) ),* ]
     }
 }
 
 #[macro_export]
 macro_rules! sequential_actions {
-    ( $( $x:expr ),* $(,)? ) => {
+    ( $( $action:expr ),* $(,)? ) => {
         $crate::ActionType::Sequence(
-            Box::new( actions![$( $x ),*].into_iter() )
+            Box::new( actions![$( $action ),*].into_iter() )
         )
     };
 }
 
 #[macro_export]
 macro_rules! parallel_actions {
-    ( $( $x:expr ),* $(,)? ) => {
+    ( $( $action:expr ),* $(,)? ) => {
         $crate::ActionType::Parallel(
-            Box::new( actions![$( $x ),*].into_iter() )
+            Box::new( actions![$( $action ),*].into_iter() )
         )
     };
 }
 
 #[macro_export]
 macro_rules! linked_actions {
-    ( $( [ $( $x:expr ),* $(,)? ] ),* $(,)? ) => {
+    ( $( [ $( $action:expr ),* $(,)? ] ),* $(,)? ) => {
         $crate::ActionType::Linked(Box::new([
             $(
-                Box::new( actions![$( $x ),*] ) as Box<[_]>,
+                Box::new( actions![$( $action ),*] ) as Box<[_]>,
             )*
         ].into_iter()))
     }

--- a/src/macros.rs
+++ b/src/macros.rs
@@ -23,24 +23,6 @@ macro_rules! actions {
     }
 }
 
-// #[macro_export]
-// macro_rules! actions {
-//     ( $( $x:expr ),* $(,)? ) => {
-//         Box::new( [ $( $crate::IntoBoxedAction::into_boxed($x) ),* ].into_iter() )
-//     }
-// }
-
-// #[macro_export]
-// macro_rules! actions_2d {
-//     ( $( [ $( $d:expr ),* $(,)? ] ),* $(,)? ) => {
-//         Box::new([
-//             $(
-//                 Box::new([ $( $crate::IntoBoxedAction::into_boxed($d) ),* ]) as Box<[_]>,
-//             )*
-//         ])
-//     }
-// }
-
 #[macro_export]
 macro_rules! sequential_actions {
     ( $( $x:expr ),* $(,)? ) => {
@@ -59,97 +41,13 @@ macro_rules! parallel_actions {
     };
 }
 
-// #[macro_export]
-// macro_rules! linked_actions {
-//     ( $( [ $( $x:expr ),* $(,)? ] ),* $(,)? ) => {
-//         $crate::ActionType::Linked(Box::new([
-//             $(
-//                 // actions![$( $x )*]
-//                 Box::new([ $( $crate::IntoBoxedAction::into_boxed($x) ),* ]) as Box<[_]>,
-//             )*
-//         ]))
-//     }
-// }
-
 #[macro_export]
 macro_rules! linked_actions {
     ( $( [ $( $x:expr ),* $(,)? ] ),* $(,)? ) => {
         $crate::ActionType::Linked(Box::new([
             $(
-                // Box::<[dyn ExactSizeIterator<Item = Empty>]>::new( acts![$( $x ),*].into_iter() ),
-                // Box::new([ $( $crate::IntoBoxedAction::into_boxed($x) ),* ]) as Box<[_]>,
                 Box::new( actions![$( $x ),*] ) as Box<[_]>,
             )*
         ].into_iter()))
-    }
-}
-
-macro_rules! acts {
-    ( $( $x:expr ),* $(,)? ) => {
-        [ $( $crate::IntoBoxedAction::into_boxed($x) ),* ]
-    }
-}
-
-// macro_rules! linked {
-//     ( $( [ $( $x:expr ),* $(,)? ] ),* $(,)? ) => {
-//         Box::new([
-//             $(
-//                 // Box::<[dyn ExactSizeIterator<Item = Empty>]>::new( acts![$( $x ),*].into_iter() ),
-//                 // Box::new([ $( $crate::IntoBoxedAction::into_boxed($x) ),* ]) as Box<[_]>,
-//                 Box::new([ $( $crate::IntoBoxedAction::into_boxed($x) ),* ]) as Box<[_]>,
-//             )*
-//         ].into_iter())
-//     }
-// }
-
-enum Yoyo {
-    Linked(Box<dyn ExactSizeIterator<Item = Box<[BoxedAction]>>>),
-}
-
-macro_rules! linked {
-    ( $( [ $( $x:expr ),* $(,)? ] ),* $(,)? ) => {
-        Yoyo::Linked(Box::new([
-            $(
-                // Box::<[dyn ExactSizeIterator<Item = Empty>]>::new( acts![$( $x ),*].into_iter() ),
-                // Box::new([ $( $crate::IntoBoxedAction::into_boxed($x) ),* ]) as Box<[_]>,
-                Box::new([ $( $crate::IntoBoxedAction::into_boxed($x) ),* ]) as Box<[_]>,
-            )*
-        ].into_iter()))
-    }
-}
-
-fn test() {
-    // let a = linked!([Empty], [Empty, Empty]);
-    // let b = a.filter(|x| !x.is_empty()).collect::<Box<[_]>>();
-
-    // let a = Box::new([Box::new([Empty]), Box::new([Empty, Empty]) as Box<[_]>].into_iter());
-    // let b = a.filter(|x| !x.is_empty()).collect::<Box<[_]>>();
-
-    let a: Box<dyn ExactSizeIterator<Item = Box<[Empty]>>> =
-        Box::new([Box::new([Empty]), Box::new([Empty, Empty]) as Box<[_]>].into_iter());
-
-    // let a = Box::<Box<dyn Iterator<Item = Box<dyn Iterator<Item = Empty>>>>>::new([
-    //     (Box::new([Empty]) as Box<[_]>).into_iter(),
-    //     (Box::new([Empty, Empty]) as Box<[_]>).into_iter(),
-    // ]);
-    // let a: Box<[Box<dyn ExactSizeIterator<Item = Empty>>; 2]> = Box::new([
-    //     Box::new([Empty].into_iter()),
-    //     Box::new([Empty, Empty].into_iter()),
-    // ]);
-
-    let b = linked![[Empty], [Empty, Empty]];
-}
-
-use bevy_ecs::entity::Entity;
-use bevy_ecs::world::World;
-
-struct Empty;
-impl Action for Empty {
-    fn on_start(&mut self, agent: Entity, world: &mut World, commands: &mut crate::ActionCommands) {
-        todo!()
-    }
-
-    fn on_stop(&mut self, agent: Entity, world: &mut World, reason: crate::StopReason) {
-        todo!()
     }
 }

--- a/src/macros.rs
+++ b/src/macros.rs
@@ -19,35 +19,35 @@ use crate::{Action, BoxedAction};
 #[macro_export]
 macro_rules! actions {
     ( $( $action:expr ),* $(,)? ) => {
-        [ $( $crate::IntoBoxedAction::into_boxed($action) ),* ]
+        [ $( $crate::IntoBoxedAction::into_boxed($action) ),* ].into_iter()
     }
 }
 
-#[macro_export]
-macro_rules! sequential_actions {
-    ( $( $action:expr ),* $(,)? ) => {
-        $crate::ActionType::Sequence(
-            Box::new( actions![$( $action ),*].into_iter() )
-        )
-    };
-}
+// #[macro_export]
+// macro_rules! sequential_actions {
+//     ( $( $action:expr ),* $(,)? ) => {
+//         $crate::ActionType::Sequence(
+//             Box::new( actions![$( $action ),*].into_iter() )
+//         )
+//     };
+// }
 
-#[macro_export]
-macro_rules! parallel_actions {
-    ( $( $action:expr ),* $(,)? ) => {
-        $crate::ActionType::Parallel(
-            Box::new( actions![$( $action ),*].into_iter() )
-        )
-    };
-}
+// #[macro_export]
+// macro_rules! parallel_actions {
+//     ( $( $action:expr ),* $(,)? ) => {
+//         $crate::ActionType::Parallel(
+//             Box::new( actions![$( $action ),*].into_iter() )
+//         )
+//     };
+// }
 
-#[macro_export]
-macro_rules! linked_actions {
-    ( $( [ $( $action:expr ),* $(,)? ] ),* $(,)? ) => {
-        $crate::ActionType::Linked(Box::new([
-            $(
-                Box::new( actions![$( $action ),*] ) as Box<[_]>,
-            )*
-        ].into_iter()))
-    }
-}
+// #[macro_export]
+// macro_rules! linked_actions {
+//     ( $( [ $( $action:expr ),* $(,)? ] ),* $(,)? ) => {
+//         $crate::ActionType::Linked(Box::new([
+//             $(
+//                 Box::new( actions![$( $action ),*] ) as Box<[_]>,
+//             )*
+//         ].into_iter()))
+//     }
+// }

--- a/src/macros.rs
+++ b/src/macros.rs
@@ -20,3 +20,14 @@ macro_rules! actions {
         Box::new( [ $( $crate::IntoBoxedAction::into_boxed($x) ),* ].into_iter() )
     };
 }
+
+#[macro_export]
+macro_rules! actions_2d {
+    [ $( [ $( $d:expr ),* $(,)? ] ),* $(,)? ] => {
+        Box::new([
+            $(
+                Box::new([ $( $crate::IntoBoxedAction::into_boxed($d) ),* ]) as Box<[_]>,
+            )*
+        ])
+    }
+}

--- a/src/macros.rs
+++ b/src/macros.rs
@@ -1,3 +1,5 @@
+use crate::{Action, BoxedAction};
+
 /// Helper macro for creating a collection of boxed actions.
 ///
 /// ```rust,no_run
@@ -46,14 +48,97 @@ macro_rules! parallel_actions {
     };
 }
 
+// #[macro_export]
+// macro_rules! linked_actions {
+//     ( $( [ $( $x:expr ),* $(,)? ] ),* $(,)? ) => {
+//         $crate::ActionType::Linked(Box::new([
+//             $(
+//                 // actions![$( $x )*]
+//                 Box::new([ $( $crate::IntoBoxedAction::into_boxed($x) ),* ]) as Box<[_]>,
+//             )*
+//         ]))
+//     }
+// }
+
 #[macro_export]
 macro_rules! linked_actions {
     ( $( [ $( $x:expr ),* $(,)? ] ),* $(,)? ) => {
         $crate::ActionType::Linked(Box::new([
             $(
-                // actions![$( $x )*]
+                // Box::<[dyn ExactSizeIterator<Item = Empty>]>::new( acts![$( $x ),*].into_iter() ),
+                // Box::new([ $( $crate::IntoBoxedAction::into_boxed($x) ),* ]) as Box<[_]>,
                 Box::new([ $( $crate::IntoBoxedAction::into_boxed($x) ),* ]) as Box<[_]>,
             )*
-        ]))
+        ].into_iter()))
+    }
+}
+
+macro_rules! acts {
+    ( $( $x:expr ),* $(,)? ) => {
+        [ $( $crate::IntoBoxedAction::into_boxed($x) ),* ]
+    }
+}
+
+// macro_rules! linked {
+//     ( $( [ $( $x:expr ),* $(,)? ] ),* $(,)? ) => {
+//         Box::new([
+//             $(
+//                 // Box::<[dyn ExactSizeIterator<Item = Empty>]>::new( acts![$( $x ),*].into_iter() ),
+//                 // Box::new([ $( $crate::IntoBoxedAction::into_boxed($x) ),* ]) as Box<[_]>,
+//                 Box::new([ $( $crate::IntoBoxedAction::into_boxed($x) ),* ]) as Box<[_]>,
+//             )*
+//         ].into_iter())
+//     }
+// }
+
+enum Yoyo {
+    Linked(Box<dyn ExactSizeIterator<Item = Box<[BoxedAction]>>>),
+}
+
+macro_rules! linked {
+    ( $( [ $( $x:expr ),* $(,)? ] ),* $(,)? ) => {
+        Yoyo::Linked(Box::new([
+            $(
+                // Box::<[dyn ExactSizeIterator<Item = Empty>]>::new( acts![$( $x ),*].into_iter() ),
+                // Box::new([ $( $crate::IntoBoxedAction::into_boxed($x) ),* ]) as Box<[_]>,
+                Box::new([ $( $crate::IntoBoxedAction::into_boxed($x) ),* ]) as Box<[_]>,
+            )*
+        ].into_iter()))
+    }
+}
+
+fn test() {
+    // let a = linked!([Empty], [Empty, Empty]);
+    // let b = a.filter(|x| !x.is_empty()).collect::<Box<[_]>>();
+
+    // let a = Box::new([Box::new([Empty]), Box::new([Empty, Empty]) as Box<[_]>].into_iter());
+    // let b = a.filter(|x| !x.is_empty()).collect::<Box<[_]>>();
+
+    let a: Box<dyn ExactSizeIterator<Item = Box<[Empty]>>> =
+        Box::new([Box::new([Empty]), Box::new([Empty, Empty]) as Box<[_]>].into_iter());
+
+    // let a = Box::<Box<dyn Iterator<Item = Box<dyn Iterator<Item = Empty>>>>>::new([
+    //     (Box::new([Empty]) as Box<[_]>).into_iter(),
+    //     (Box::new([Empty, Empty]) as Box<[_]>).into_iter(),
+    // ]);
+    // let a: Box<[Box<dyn ExactSizeIterator<Item = Empty>>; 2]> = Box::new([
+    //     Box::new([Empty].into_iter()),
+    //     Box::new([Empty, Empty].into_iter()),
+    // ]);
+
+    let b = linked![[Empty], [Empty, Empty]];
+}
+
+use bevy_ecs::entity::Entity;
+use bevy_ecs::world::World;
+
+struct Empty;
+impl Action for Empty {
+    fn on_start(&mut self, agent: Entity, world: &mut World, commands: &mut crate::ActionCommands) {
+        todo!()
+    }
+
+    fn on_stop(&mut self, agent: Entity, world: &mut World, reason: crate::StopReason) {
+        todo!()
     }
 }

--- a/src/macros.rs
+++ b/src/macros.rs
@@ -17,6 +17,6 @@
 #[macro_export]
 macro_rules! actions {
     ( $( $x:expr ),* $(,)? ) => {
-        [ $( $crate::IntoBoxedAction::into_boxed($x) ),* ].into_iter()
+        Box::new( [ $( $crate::IntoBoxedAction::into_boxed($x) ),* ].into_iter() )
     };
 }

--- a/src/macros.rs
+++ b/src/macros.rs
@@ -1,5 +1,3 @@
-use crate::{Action, BoxedAction};
-
 /// Helper macro for creating a collection of boxed actions.
 ///
 /// ```rust,no_run
@@ -22,32 +20,3 @@ macro_rules! actions {
         [ $( $crate::IntoBoxedAction::into_boxed($action) ),* ].into_iter()
     }
 }
-
-// #[macro_export]
-// macro_rules! sequential_actions {
-//     ( $( $action:expr ),* $(,)? ) => {
-//         $crate::ActionType::Sequence(
-//             Box::new( actions![$( $action ),*].into_iter() )
-//         )
-//     };
-// }
-
-// #[macro_export]
-// macro_rules! parallel_actions {
-//     ( $( $action:expr ),* $(,)? ) => {
-//         $crate::ActionType::Parallel(
-//             Box::new( actions![$( $action ),*].into_iter() )
-//         )
-//     };
-// }
-
-// #[macro_export]
-// macro_rules! linked_actions {
-//     ( $( [ $( $action:expr ),* $(,)? ] ),* $(,)? ) => {
-//         $crate::ActionType::Linked(Box::new([
-//             $(
-//                 Box::new( actions![$( $action ),*] ) as Box<[_]>,
-//             )*
-//         ].into_iter()))
-//     }
-// }

--- a/src/macros.rs
+++ b/src/macros.rs
@@ -21,13 +21,39 @@ macro_rules! actions {
     }
 }
 
+// #[macro_export]
+// macro_rules! actions_2d {
+//     ( $( [ $( $d:expr ),* $(,)? ] ),* $(,)? ) => {
+//         Box::new([
+//             $(
+//                 Box::new([ $( $crate::IntoBoxedAction::into_boxed($d) ),* ]) as Box<[_]>,
+//             )*
+//         ])
+//     }
+// }
+
 #[macro_export]
-macro_rules! actions_2d {
-    ( $( [ $( $d:expr ),* $(,)? ] ),* $(,)? ) => {
-        Box::new([
+macro_rules! sequential_actions {
+    ( $( $x:expr ),* $(,)? ) => {
+        $crate::ActionType::Sequence(actions![$( $x )*])
+    };
+}
+
+#[macro_export]
+macro_rules! parallel_actions {
+    ( $( $x:expr ),* $(,)? ) => {
+        $crate::ActionType::Parallel(actions![$( $x )*])
+    };
+}
+
+#[macro_export]
+macro_rules! linked_actions {
+    ( $( [ $( $x:expr ),* $(,)? ] ),* $(,)? ) => {
+        $crate::ActionType::Linked(Box::new([
             $(
-                Box::new([ $( $crate::IntoBoxedAction::into_boxed($d) ),* ]) as Box<[_]>,
+                // actions![$( $x )*]
+                Box::new([ $( $crate::IntoBoxedAction::into_boxed($x) ),* ]) as Box<[_]>,
             )*
-        ])
+        ]))
     }
 }

--- a/src/macros.rs
+++ b/src/macros.rs
@@ -18,12 +18,12 @@
 macro_rules! actions {
     ( $( $x:expr ),* $(,)? ) => {
         Box::new( [ $( $crate::IntoBoxedAction::into_boxed($x) ),* ].into_iter() )
-    };
+    }
 }
 
 #[macro_export]
 macro_rules! actions_2d {
-    [ $( [ $( $d:expr ),* $(,)? ] ),* $(,)? ] => {
+    ( $( [ $( $d:expr ),* $(,)? ] ),* $(,)? ) => {
         Box::new([
             $(
                 Box::new([ $( $crate::IntoBoxedAction::into_boxed($d) ),* ]) as Box<[_]>,

--- a/src/macros.rs
+++ b/src/macros.rs
@@ -3,12 +3,14 @@
 /// ```rust,no_run
 /// # use bevy::prelude::*;
 /// # use bevy_sequential_actions::*;
-/// # use shared::actions::*;
+/// # use shared::actions::QuitAction;
 /// #
-/// let actions: std::array::IntoIter<BoxedAction, 4> = actions![
-///         QuitAction,
-///         DespawnAction,
-///         WaitAction::new(1.0),
+/// # let action_a = QuitAction;
+/// # let action_b = QuitAction;
+/// #
+/// let actions: std::array::IntoIter<BoxedAction, 3> = actions![
+///         action_a,
+///         action_b,
 ///         |agent: Entity, world: &mut World, commands: &mut ActionCommands| {
 ///             // on_start
 ///         },

--- a/src/macros.rs
+++ b/src/macros.rs
@@ -19,9 +19,16 @@ use crate::{Action, BoxedAction};
 #[macro_export]
 macro_rules! actions {
     ( $( $x:expr ),* $(,)? ) => {
-        Box::new( [ $( $crate::IntoBoxedAction::into_boxed($x) ),* ].into_iter() )
+        [ $( $crate::IntoBoxedAction::into_boxed($x) ),* ]
     }
 }
+
+// #[macro_export]
+// macro_rules! actions {
+//     ( $( $x:expr ),* $(,)? ) => {
+//         Box::new( [ $( $crate::IntoBoxedAction::into_boxed($x) ),* ].into_iter() )
+//     }
+// }
 
 // #[macro_export]
 // macro_rules! actions_2d {
@@ -37,14 +44,18 @@ macro_rules! actions {
 #[macro_export]
 macro_rules! sequential_actions {
     ( $( $x:expr ),* $(,)? ) => {
-        $crate::ActionType::Sequence(actions![$( $x )*])
+        $crate::ActionType::Sequence(
+            Box::new( actions![$( $x ),*].into_iter() )
+        )
     };
 }
 
 #[macro_export]
 macro_rules! parallel_actions {
     ( $( $x:expr ),* $(,)? ) => {
-        $crate::ActionType::Parallel(actions![$( $x )*])
+        $crate::ActionType::Parallel(
+            Box::new( actions![$( $x ),*].into_iter() )
+        )
     };
 }
 
@@ -67,7 +78,7 @@ macro_rules! linked_actions {
             $(
                 // Box::<[dyn ExactSizeIterator<Item = Empty>]>::new( acts![$( $x ),*].into_iter() ),
                 // Box::new([ $( $crate::IntoBoxedAction::into_boxed($x) ),* ]) as Box<[_]>,
-                Box::new([ $( $crate::IntoBoxedAction::into_boxed($x) ),* ]) as Box<[_]>,
+                Box::new( actions![$( $x ),*] ) as Box<[_]>,
             )*
         ].into_iter()))
     }

--- a/src/plugin.rs
+++ b/src/plugin.rs
@@ -59,9 +59,9 @@ fn check_actions(
         if let Some((current_action, _)) = &current_action.0 {
             let finished_count = finished.total();
             let active_count = match current_action {
-                ActionTypeInternal::One(..) => 1,
+                ActionTypeInternal::One(_) => 1,
                 ActionTypeInternal::Many(actions) => actions.len(),
-                ActionTypeInternal::Linked(..) => 1,
+                ActionTypeInternal::Linked(actions, index) => actions[*index].len(),
             } as u32;
 
             match finished_count.cmp(&active_count) {

--- a/src/plugin.rs
+++ b/src/plugin.rs
@@ -59,10 +59,10 @@ fn check_actions(
         if let Some((current_action, _)) = &current_action.0 {
             let finished_count = finished.total();
             let active_count = match current_action {
-                ActionType::Single(_) => todo!(),
-                ActionType::Parallel(_) => todo!(),
-                ActionType::Linked(_, _) => todo!(),
-            };
+                ActionType::Single(_) => 1,
+                ActionType::Parallel(actions) => actions.len(),
+                ActionType::Linked(_, _) => 1,
+            } as u32;
 
             match finished_count.cmp(&active_count) {
                 Ordering::Less => {}

--- a/src/plugin.rs
+++ b/src/plugin.rs
@@ -59,9 +59,9 @@ fn check_actions(
         if let Some((current_action, _)) = &current_action.0 {
             let finished_count = finished.total();
             let active_count = match current_action {
-                ActionType::Single(..) => 1,
-                ActionType::Parallel(actions) => actions.len(),
-                ActionType::Linked(..) => 1,
+                InternalActionType::Single(..) => 1,
+                InternalActionType::Parallel(actions) => actions.len(),
+                InternalActionType::Linked(..) => 1,
             } as u32;
 
             match finished_count.cmp(&active_count) {

--- a/src/plugin.rs
+++ b/src/plugin.rs
@@ -58,7 +58,11 @@ fn check_actions(
     for (agent, current_action, finished) in action_q.iter() {
         if let Some((current_action, _)) = &current_action.0 {
             let finished_count = finished.total();
-            let active_count = current_action.len();
+            let active_count = match current_action {
+                ActionType::Single(_) => todo!(),
+                ActionType::Parallel(_) => todo!(),
+                ActionType::Linked(_, _) => todo!(),
+            };
 
             match finished_count.cmp(&active_count) {
                 Ordering::Less => {}

--- a/src/plugin.rs
+++ b/src/plugin.rs
@@ -59,9 +59,9 @@ fn check_actions(
         if let Some((current_action, _)) = &current_action.0 {
             let finished_count = finished.total();
             let active_count = match current_action {
-                InternalActionType::Single(..) => 1,
-                InternalActionType::Parallel(actions) => actions.len(),
-                InternalActionType::Linked(..) => 1,
+                ActionTypeInternal::One(..) => 1,
+                ActionTypeInternal::Many(actions) => actions.len(),
+                ActionTypeInternal::Linked(..) => 1,
             } as u32;
 
             match finished_count.cmp(&active_count) {

--- a/src/plugin.rs
+++ b/src/plugin.rs
@@ -58,11 +58,7 @@ fn check_actions(
     for (agent, current_action, finished) in action_q.iter() {
         if let Some((current_action, _)) = &current_action.0 {
             let finished_count = finished.total();
-            let active_count = match current_action {
-                ActionTypeInternal::One(_) => 1,
-                ActionTypeInternal::Many(actions) => actions.len(),
-                ActionTypeInternal::Linked(actions, index) => actions[*index].len(),
-            } as u32;
+            let active_count = current_action.len();
 
             match finished_count.cmp(&active_count) {
                 Ordering::Less => {}

--- a/src/plugin.rs
+++ b/src/plugin.rs
@@ -59,9 +59,9 @@ fn check_actions(
         if let Some((current_action, _)) = &current_action.0 {
             let finished_count = finished.total();
             let active_count = match current_action {
-                ActionType::Single(_) => 1,
+                ActionType::Single(..) => 1,
                 ActionType::Parallel(actions) => actions.len(),
-                ActionType::Linked(_, _) => 1,
+                ActionType::Linked(..) => 1,
             } as u32;
 
             match finished_count.cmp(&active_count) {

--- a/src/tests.rs
+++ b/src/tests.rs
@@ -232,6 +232,12 @@ fn add_many_empty() {
         .add(linked_actions![]);
 
     assert!(ecs.current_action(e).is_none());
+
+    ecs.actions(e).add_linked(|builder| {
+        builder
+            .add(CountdownAction::new(0))
+            .add_sequence(actions![CountdownAction::new(0)].into_iter());
+    });
 }
 
 #[test]

--- a/src/tests.rs
+++ b/src/tests.rs
@@ -1021,34 +1021,3 @@ fn finished_exceeds_active_panic() {
 
     ecs.run();
 }
-
-macro_rules! foo {
-    ( $( $l:tt ),* $(,)? ) => {
-        Box::new([ $( bar!($l) ),* ])
-    };
-}
-
-macro_rules! bar {
-    [ $( [ $( $d:expr ),* $(,)? ] ),* $(,)? ] => {
-        Box::new([
-            $(
-                $( $d ),*
-            )*
-        ]) as Box<[_]>
-    };
-
-    ( $( $x:expr ),* $(,)? ) => {
-        Box::new( [ $( $x ),* ] )
-    };
-}
-
-#[test]
-fn test() {
-    let a = foo!(1, [3, 2], [2], [21], 22, 1, [0]);
-    for a in a.iter() {
-        print!("\t");
-        for b in a.iter() {
-            print!("{} ", b);
-        }
-    }
-}

--- a/src/tests.rs
+++ b/src/tests.rs
@@ -171,15 +171,11 @@ fn add_many_sequential() {
     let mut ecs = Ecs::new();
     let e = ecs.spawn_agent();
 
-    ecs.actions(e).add_many(
-        ExecutionMode::Sequential,
-        [
-            CountdownAction::new(0).into_boxed(),
-            CountdownAction::new(0).into_boxed(),
-            CountdownAction::new(0).into_boxed(),
-        ]
-        .into_iter(),
-    );
+    ecs.actions(e).add(ActionKind::Sequence(actions![
+        CountdownAction::new(0),
+        CountdownAction::new(0),
+        CountdownAction::new(0),
+    ]));
 
     assert!(ecs.current_action(e).is_some());
     assert!(ecs.action_queue(e).len() == 2);
@@ -190,52 +186,48 @@ fn add_many_parallel() {
     let mut ecs = Ecs::new();
     let e = ecs.spawn_agent();
 
-    ecs.actions(e).add_many(
-        ExecutionMode::Parallel,
-        [
-            CountdownAction::new(0).into_boxed(),
-            CountdownAction::new(0).into_boxed(),
-            CountdownAction::new(0).into_boxed(),
-        ]
-        .into_iter(),
-    );
+    ecs.actions(e).add(ActionKind::Parallel(actions![
+        CountdownAction::new(0),
+        CountdownAction::new(0),
+        CountdownAction::new(0),
+    ]));
 
     assert!(ecs.current_action(e).is_some());
     assert!(ecs.action_queue(e).len() == 0);
     assert!(ecs.world.query::<&Countdown>().iter(&mut ecs.world).count() == 3);
 }
 
-#[test]
-fn add_many_linked() {
-    let mut ecs = Ecs::new();
-    let e = ecs.spawn_agent();
+// #[test]
+// fn add_many_linked() {
+//     let mut ecs = Ecs::new();
+//     let e = ecs.spawn_agent();
 
-    ecs.actions(e).add_many(
-        ExecutionMode::Linked,
-        actions![
-            CountdownAction::new(0),
-            CountdownAction::new(0),
-            CountdownAction::new(0),
-        ],
-    );
+//     ecs.actions(e).add(
+//         ExecutionMode::Linked,
+//         actions![
+//             CountdownAction::new(0),
+//             CountdownAction::new(0),
+//             CountdownAction::new(0),
+//         ],
+//     );
 
-    assert!(ecs.current_action(e).is_some());
-    assert!(ecs.action_queue(e).len() == 0);
-    assert!(ecs.world.query::<&Countdown>().iter(&mut ecs.world).count() == 1);
-}
+//     assert!(ecs.current_action(e).is_some());
+//     assert!(ecs.action_queue(e).len() == 0);
+//     assert!(ecs.world.query::<&Countdown>().iter(&mut ecs.world).count() == 1);
+// }
 
-#[test]
-fn add_many_empty() {
-    let mut ecs = Ecs::new();
-    let e = ecs.spawn_agent();
+// #[test]
+// fn add_many_empty() {
+//     let mut ecs = Ecs::new();
+//     let e = ecs.spawn_agent();
 
-    ecs.actions(e)
-        .add_many(ExecutionMode::Sequential, actions![])
-        .add_many(ExecutionMode::Parallel, actions![])
-        .add_many(ExecutionMode::Linked, actions![]);
+//     ecs.actions(e)
+//         .add_many(ExecutionMode::Sequential, actions![])
+//         .add_many(ExecutionMode::Parallel, actions![])
+//         .add_many(ExecutionMode::Linked, actions![]);
 
-    assert!(ecs.current_action(e).is_none());
-}
+//     assert!(ecs.current_action(e).is_none());
+// }
 
 #[test]
 fn next() {
@@ -258,14 +250,11 @@ fn next_parallel() {
     let mut ecs = Ecs::new();
     let e = ecs.spawn_agent();
 
-    ecs.actions(e).add_many(
-        ExecutionMode::Parallel,
-        actions![
-            CountdownAction::new(0),
-            CountdownAction::new(0),
-            CountdownAction::new(0),
-        ],
-    );
+    ecs.actions(e).add(ActionKind::Parallel(actions![
+        CountdownAction::new(0),
+        CountdownAction::new(0),
+        CountdownAction::new(0),
+    ]));
 
     assert!(ecs.current_action(e).is_some());
     assert!(ecs.action_queue(e).len() == 0);
@@ -278,30 +267,27 @@ fn next_parallel() {
     assert!(ecs.world.query::<&Countdown>().iter(&mut ecs.world).count() == 0);
 }
 
-#[test]
-fn next_linked() {
-    let mut ecs = Ecs::new();
-    let e = ecs.spawn_agent();
+// #[test]
+// fn next_linked() {
+//     let mut ecs = Ecs::new();
+//     let e = ecs.spawn_agent();
 
-    ecs.actions(e).add_many(
-        ExecutionMode::Linked,
-        actions![
-            CountdownAction::new(0),
-            CountdownAction::new(0),
-            CountdownAction::new(0),
-        ],
-    );
+//     ecs.actions(e).add(ActionKind::Linked(actions![
+//         CountdownAction::new(0),
+//         CountdownAction::new(0),
+//         CountdownAction::new(0),
+//     ]));
 
-    assert!(ecs.current_action(e).is_some());
-    assert!(ecs.action_queue(e).len() == 0);
-    assert!(ecs.world.query::<&Countdown>().iter(&mut ecs.world).count() == 1);
+//     assert!(ecs.current_action(e).is_some());
+//     assert!(ecs.action_queue(e).len() == 0);
+//     assert!(ecs.world.query::<&Countdown>().iter(&mut ecs.world).count() == 1);
 
-    ecs.actions(e).next();
+//     ecs.actions(e).next();
 
-    assert!(ecs.current_action(e).is_none());
-    assert!(ecs.action_queue(e).len() == 0);
-    assert!(ecs.world.query::<&Countdown>().iter(&mut ecs.world).count() == 0);
-}
+//     assert!(ecs.current_action(e).is_none());
+//     assert!(ecs.action_queue(e).len() == 0);
+//     assert!(ecs.world.query::<&Countdown>().iter(&mut ecs.world).count() == 0);
+// }
 
 #[test]
 #[should_panic]
@@ -332,14 +318,11 @@ fn finish_parallel() {
     let mut ecs = Ecs::new();
     let e = ecs.spawn_agent();
 
-    ecs.actions(e).add_many(
-        ExecutionMode::Parallel,
-        actions![
-            CountdownAction::new(0),
-            CountdownAction::new(0),
-            CountdownAction::new(0),
-        ],
-    );
+    ecs.actions(e).add(ActionKind::Parallel(actions![
+        CountdownAction::new(0),
+        CountdownAction::new(0),
+        CountdownAction::new(0),
+    ]));
 
     assert!(ecs.current_action(e).is_some());
     assert!(ecs.action_queue(e).len() == 0);
@@ -352,42 +335,39 @@ fn finish_parallel() {
     assert!(ecs.world.query::<&Countdown>().iter(&mut ecs.world).count() == 0);
 }
 
-#[test]
-fn finish_linked() {
-    let mut ecs = Ecs::new();
-    let e = ecs.spawn_agent();
+// #[test]
+// fn finish_linked() {
+//     let mut ecs = Ecs::new();
+//     let e = ecs.spawn_agent();
 
-    ecs.actions(e).add_many(
-        ExecutionMode::Linked,
-        actions![
-            CountdownAction::new(0),
-            CountdownAction::new(0),
-            CountdownAction::new(0),
-        ],
-    );
+//     ecs.actions(e).add(ActionKind::Linked(actions![
+//         CountdownAction::new(0),
+//         CountdownAction::new(0),
+//         CountdownAction::new(0),
+//     ]));
 
-    assert!(ecs.current_action(e).is_some());
-    assert!(ecs.action_queue(e).len() == 0);
-    assert!(ecs.world.query::<&Countdown>().iter(&mut ecs.world).count() == 1);
+//     assert!(ecs.current_action(e).is_some());
+//     assert!(ecs.action_queue(e).len() == 0);
+//     assert!(ecs.world.query::<&Countdown>().iter(&mut ecs.world).count() == 1);
 
-    ecs.run();
+//     ecs.run();
 
-    assert!(ecs.current_action(e).is_some());
-    assert!(ecs.action_queue(e).len() == 0);
-    assert!(ecs.world.query::<&Countdown>().iter(&mut ecs.world).count() == 1);
+//     assert!(ecs.current_action(e).is_some());
+//     assert!(ecs.action_queue(e).len() == 0);
+//     assert!(ecs.world.query::<&Countdown>().iter(&mut ecs.world).count() == 1);
 
-    ecs.run();
+//     ecs.run();
 
-    assert!(ecs.current_action(e).is_some());
-    assert!(ecs.action_queue(e).len() == 0);
-    assert!(ecs.world.query::<&Countdown>().iter(&mut ecs.world).count() == 1);
+//     assert!(ecs.current_action(e).is_some());
+//     assert!(ecs.action_queue(e).len() == 0);
+//     assert!(ecs.world.query::<&Countdown>().iter(&mut ecs.world).count() == 1);
 
-    ecs.run();
+//     ecs.run();
 
-    assert!(ecs.current_action(e).is_none());
-    assert!(ecs.action_queue(e).len() == 0);
-    assert!(ecs.world.query::<&Countdown>().iter(&mut ecs.world).count() == 0);
-}
+//     assert!(ecs.current_action(e).is_none());
+//     assert!(ecs.action_queue(e).len() == 0);
+//     assert!(ecs.world.query::<&Countdown>().iter(&mut ecs.world).count() == 0);
+// }
 
 #[test]
 fn cancel() {
@@ -410,14 +390,11 @@ fn cancel_parallel() {
     let mut ecs = Ecs::new();
     let e = ecs.spawn_agent();
 
-    ecs.actions(e).add_many(
-        ExecutionMode::Parallel,
-        actions![
-            CountdownAction::new(0),
-            CountdownAction::new(0),
-            CountdownAction::new(0),
-        ],
-    );
+    ecs.actions(e).add(ActionKind::Parallel(actions![
+        CountdownAction::new(0),
+        CountdownAction::new(0),
+        CountdownAction::new(0),
+    ]));
 
     assert!(ecs.current_action(e).is_some());
     assert!(ecs.action_queue(e).len() == 0);
@@ -430,30 +407,30 @@ fn cancel_parallel() {
     assert!(ecs.world.query::<&Countdown>().iter(&mut ecs.world).count() == 0);
 }
 
-#[test]
-fn cancel_linked() {
-    let mut ecs = Ecs::new();
-    let e = ecs.spawn_agent();
+// #[test]
+// fn cancel_linked() {
+//     let mut ecs = Ecs::new();
+//     let e = ecs.spawn_agent();
 
-    ecs.actions(e).add_many(
-        ExecutionMode::Linked,
-        actions![
-            CountdownAction::new(0),
-            CountdownAction::new(0),
-            CountdownAction::new(0),
-        ],
-    );
+//     ecs.actions(e).add(
+//         ExecutionMode::Linked,
+//         actions![
+//             CountdownAction::new(0),
+//             CountdownAction::new(0),
+//             CountdownAction::new(0),
+//         ],
+//     );
 
-    assert!(ecs.current_action(e).is_some());
-    assert!(ecs.action_queue(e).len() == 0);
-    assert!(ecs.world.query::<&Countdown>().iter(&mut ecs.world).count() == 1);
+//     assert!(ecs.current_action(e).is_some());
+//     assert!(ecs.action_queue(e).len() == 0);
+//     assert!(ecs.world.query::<&Countdown>().iter(&mut ecs.world).count() == 1);
 
-    ecs.actions(e).cancel();
+//     ecs.actions(e).cancel();
 
-    assert!(ecs.current_action(e).is_none());
-    assert!(ecs.action_queue(e).len() == 0);
-    assert!(ecs.world.query::<&Countdown>().iter(&mut ecs.world).count() == 0);
-}
+//     assert!(ecs.current_action(e).is_none());
+//     assert!(ecs.action_queue(e).len() == 0);
+//     assert!(ecs.world.query::<&Countdown>().iter(&mut ecs.world).count() == 0);
+// }
 
 #[test]
 fn pause() {
@@ -476,14 +453,11 @@ fn pause_parallel() {
     let mut ecs = Ecs::new();
     let e = ecs.spawn_agent();
 
-    ecs.actions(e).add_many(
-        ExecutionMode::Parallel,
-        actions![
-            CountdownAction::new(0),
-            CountdownAction::new(0),
-            CountdownAction::new(0),
-        ],
-    );
+    ecs.actions(e).add(ActionKind::Parallel(actions![
+        CountdownAction::new(0),
+        CountdownAction::new(0),
+        CountdownAction::new(0),
+    ]));
 
     assert!(ecs.current_action(e).is_some());
     assert!(ecs.action_queue(e).len() == 0);
@@ -496,30 +470,30 @@ fn pause_parallel() {
     assert!(ecs.world.query::<&Countdown>().iter(&mut ecs.world).count() == 0);
 }
 
-#[test]
-fn pause_linked() {
-    let mut ecs = Ecs::new();
-    let e = ecs.spawn_agent();
+// #[test]
+// fn pause_linked() {
+//     let mut ecs = Ecs::new();
+//     let e = ecs.spawn_agent();
 
-    ecs.actions(e).add_many(
-        ExecutionMode::Linked,
-        actions![
-            CountdownAction::new(0),
-            CountdownAction::new(0),
-            CountdownAction::new(0),
-        ],
-    );
+//     ecs.actions(e).add_many(
+//         ExecutionMode::Linked,
+//         actions![
+//             CountdownAction::new(0),
+//             CountdownAction::new(0),
+//             CountdownAction::new(0),
+//         ],
+//     );
 
-    assert!(ecs.current_action(e).is_some());
-    assert!(ecs.action_queue(e).len() == 0);
-    assert!(ecs.world.query::<&Countdown>().iter(&mut ecs.world).count() == 1);
+//     assert!(ecs.current_action(e).is_some());
+//     assert!(ecs.action_queue(e).len() == 0);
+//     assert!(ecs.world.query::<&Countdown>().iter(&mut ecs.world).count() == 1);
 
-    ecs.actions(e).pause();
+//     ecs.actions(e).pause();
 
-    assert!(ecs.current_action(e).is_none());
-    assert!(ecs.action_queue(e).len() == 1);
-    assert!(ecs.world.query::<&Countdown>().iter(&mut ecs.world).count() == 0);
-}
+//     assert!(ecs.current_action(e).is_none());
+//     assert!(ecs.action_queue(e).len() == 1);
+//     assert!(ecs.world.query::<&Countdown>().iter(&mut ecs.world).count() == 0);
+// }
 
 #[test]
 #[should_panic]
@@ -592,28 +566,28 @@ fn skip_parallel() {
             start: false,
             repeat: Repeat::None,
         })
-        .add_many(
-            ExecutionMode::Parallel,
-            actions![CountdownAction::new(0), CountdownAction::new(0)],
-        )
+        .add(ActionKind::Parallel(actions![
+            CountdownAction::new(0),
+            CountdownAction::new(0)
+        ]))
         .config(AddConfig {
             order: AddOrder::Back,
             start: false,
             repeat: Repeat::Amount(1),
         })
-        .add_many(
-            ExecutionMode::Parallel,
-            actions![CountdownAction::new(0), CountdownAction::new(0)],
-        )
+        .add(ActionKind::Parallel(actions![
+            CountdownAction::new(0),
+            CountdownAction::new(0)
+        ]))
         .config(AddConfig {
             order: AddOrder::Back,
             start: false,
             repeat: Repeat::Forever,
         })
-        .add_many(
-            ExecutionMode::Parallel,
-            actions![CountdownAction::new(0), CountdownAction::new(0)],
-        );
+        .add(ActionKind::Parallel(actions![
+            CountdownAction::new(0),
+            CountdownAction::new(0)
+        ]));
 
     assert!(ecs.action_queue(e).len() == 3);
 
@@ -642,66 +616,66 @@ fn skip_parallel() {
     assert!(ecs.action_queue(e).len() == 1);
 }
 
-#[test]
-fn skip_linked() {
-    let mut ecs = Ecs::new();
-    let e = ecs.spawn_agent();
+// #[test]
+// fn skip_linked() {
+//     let mut ecs = Ecs::new();
+//     let e = ecs.spawn_agent();
 
-    ecs.actions(e)
-        .config(AddConfig {
-            order: AddOrder::Back,
-            start: false,
-            repeat: Repeat::None,
-        })
-        .add_many(
-            ExecutionMode::Linked,
-            actions![CountdownAction::new(0), CountdownAction::new(0)],
-        )
-        .config(AddConfig {
-            order: AddOrder::Back,
-            start: false,
-            repeat: Repeat::Amount(1),
-        })
-        .add_many(
-            ExecutionMode::Linked,
-            actions![CountdownAction::new(0), CountdownAction::new(0)],
-        )
-        .config(AddConfig {
-            order: AddOrder::Back,
-            start: false,
-            repeat: Repeat::Forever,
-        })
-        .add_many(
-            ExecutionMode::Linked,
-            actions![CountdownAction::new(0), CountdownAction::new(0)],
-        );
+//     ecs.actions(e)
+//         .config(AddConfig {
+//             order: AddOrder::Back,
+//             start: false,
+//             repeat: Repeat::None,
+//         })
+//         .add_many(
+//             ExecutionMode::Linked,
+//             actions![CountdownAction::new(0), CountdownAction::new(0)],
+//         )
+//         .config(AddConfig {
+//             order: AddOrder::Back,
+//             start: false,
+//             repeat: Repeat::Amount(1),
+//         })
+//         .add_many(
+//             ExecutionMode::Linked,
+//             actions![CountdownAction::new(0), CountdownAction::new(0)],
+//         )
+//         .config(AddConfig {
+//             order: AddOrder::Back,
+//             start: false,
+//             repeat: Repeat::Forever,
+//         })
+//         .add_many(
+//             ExecutionMode::Linked,
+//             actions![CountdownAction::new(0), CountdownAction::new(0)],
+//         );
 
-    assert!(ecs.action_queue(e).len() == 3);
+//     assert!(ecs.action_queue(e).len() == 3);
 
-    ecs.actions(e).skip();
+//     ecs.actions(e).skip();
 
-    assert!(ecs.action_queue(e).len() == 2);
+//     assert!(ecs.action_queue(e).len() == 2);
 
-    ecs.actions(e).skip();
+//     ecs.actions(e).skip();
 
-    assert!(ecs.action_queue(e).len() == 2);
+//     assert!(ecs.action_queue(e).len() == 2);
 
-    ecs.actions(e).skip();
+//     ecs.actions(e).skip();
 
-    assert!(ecs.action_queue(e).len() == 2);
+//     assert!(ecs.action_queue(e).len() == 2);
 
-    ecs.actions(e).skip();
+//     ecs.actions(e).skip();
 
-    assert!(ecs.action_queue(e).len() == 1);
+//     assert!(ecs.action_queue(e).len() == 1);
 
-    ecs.actions(e).skip();
+//     ecs.actions(e).skip();
 
-    assert!(ecs.action_queue(e).len() == 1);
+//     assert!(ecs.action_queue(e).len() == 1);
 
-    ecs.actions(e).skip();
+//     ecs.actions(e).skip();
 
-    assert!(ecs.action_queue(e).len() == 1);
-}
+//     assert!(ecs.action_queue(e).len() == 1);
+// }
 
 #[test]
 fn clear() {
@@ -857,15 +831,11 @@ fn order() {
     let e = ecs.spawn_agent();
 
     // A, B, C
-    ecs.actions(e).add_many(
-        ExecutionMode::Sequential,
-        [
-            Order::<A>::default().into_boxed(),
-            Order::<B>::default().into_boxed(),
-            Order::<C>::default().into_boxed(),
-        ]
-        .into_iter(),
-    );
+    ecs.actions(e).add(ActionKind::Sequence(actions![
+        Order::<A>::default(),
+        Order::<B>::default(),
+        Order::<C>::default(),
+    ]));
 
     assert!(ecs.world.entity(e).contains::<A>());
 
@@ -885,15 +855,11 @@ fn order() {
             start: false,
             repeat: Repeat::Amount(0),
         })
-        .add_many(
-            ExecutionMode::Sequential,
-            [
-                Order::<A>::default().into_boxed(),
-                Order::<B>::default().into_boxed(),
-                Order::<C>::default().into_boxed(),
-            ]
-            .into_iter(),
-        )
+        .add(ActionKind::Sequence(actions![
+            Order::<A>::default(),
+            Order::<B>::default(),
+            Order::<C>::default(),
+        ]))
         .next();
 
     assert!(ecs.world.entity(e).contains::<A>());
@@ -914,15 +880,11 @@ fn order() {
             start: false,
             repeat: Repeat::Amount(0),
         })
-        .add_many(
-            ExecutionMode::Sequential,
-            [
-                Order::<C>::default().into_boxed(),
-                Order::<B>::default().into_boxed(),
-                Order::<A>::default().into_boxed(),
-            ]
-            .into_iter(),
-        )
+        .add(ActionKind::Sequence(actions![
+            Order::<C>::default(),
+            Order::<B>::default(),
+            Order::<A>::default(),
+        ]))
         .next();
 
     assert!(ecs.world.entity(e).contains::<C>());
@@ -980,14 +942,11 @@ fn reset_count() {
     let mut ecs = Ecs::new();
     let e = ecs.spawn_agent();
 
-    ecs.actions(e).add_many(
-        ExecutionMode::Parallel,
-        actions![
-            CountdownAction::new(0),
-            CountdownAction::new(1),
-            CountdownAction::new(2),
-        ],
-    );
+    ecs.actions(e).add(ActionKind::Parallel(actions![
+        CountdownAction::new(0),
+        CountdownAction::new(1),
+        CountdownAction::new(2),
+    ]));
 
     assert!(ecs.action_finished(e).reset_count == 0);
 

--- a/src/tests.rs
+++ b/src/tests.rs
@@ -197,37 +197,34 @@ fn add_many_parallel() {
     assert!(ecs.world.query::<&Countdown>().iter(&mut ecs.world).count() == 3);
 }
 
-// #[test]
-// fn add_many_linked() {
-//     let mut ecs = Ecs::new();
-//     let e = ecs.spawn_agent();
+#[test]
+fn add_many_linked() {
+    let mut ecs = Ecs::new();
+    let e = ecs.spawn_agent();
 
-//     ecs.actions(e).add(
-//         ExecutionMode::Linked,
-//         actions![
-//             CountdownAction::new(0),
-//             CountdownAction::new(0),
-//             CountdownAction::new(0),
-//         ],
-//     );
+    ecs.actions(e).add(ActionKind::Linked(actions_2d![
+        [CountdownAction::new(0)],
+        [CountdownAction::new(0)],
+        [CountdownAction::new(0)],
+    ]));
 
-//     assert!(ecs.current_action(e).is_some());
-//     assert!(ecs.action_queue(e).len() == 0);
-//     assert!(ecs.world.query::<&Countdown>().iter(&mut ecs.world).count() == 1);
-// }
+    assert!(ecs.current_action(e).is_some());
+    assert!(ecs.action_queue(e).len() == 0);
+    assert!(ecs.world.query::<&Countdown>().iter(&mut ecs.world).count() == 1);
+}
 
-// #[test]
-// fn add_many_empty() {
-//     let mut ecs = Ecs::new();
-//     let e = ecs.spawn_agent();
+#[test]
+fn add_many_empty() {
+    let mut ecs = Ecs::new();
+    let e = ecs.spawn_agent();
 
-//     ecs.actions(e)
-//         .add_many(ExecutionMode::Sequential, actions![])
-//         .add_many(ExecutionMode::Parallel, actions![])
-//         .add_many(ExecutionMode::Linked, actions![]);
+    ecs.actions(e)
+        .add(ActionKind::Sequence(actions![]))
+        .add(ActionKind::Parallel(actions![]))
+        .add(ActionKind::Linked(actions_2d![]));
 
-//     assert!(ecs.current_action(e).is_none());
-// }
+    assert!(ecs.current_action(e).is_none());
+}
 
 #[test]
 fn next() {
@@ -267,27 +264,27 @@ fn next_parallel() {
     assert!(ecs.world.query::<&Countdown>().iter(&mut ecs.world).count() == 0);
 }
 
-// #[test]
-// fn next_linked() {
-//     let mut ecs = Ecs::new();
-//     let e = ecs.spawn_agent();
+#[test]
+fn next_linked() {
+    let mut ecs = Ecs::new();
+    let e = ecs.spawn_agent();
 
-//     ecs.actions(e).add(ActionKind::Linked(actions![
-//         CountdownAction::new(0),
-//         CountdownAction::new(0),
-//         CountdownAction::new(0),
-//     ]));
+    ecs.actions(e).add(ActionKind::Linked(actions_2d![
+        [CountdownAction::new(0)],
+        [CountdownAction::new(0)],
+        [CountdownAction::new(0)],
+    ]));
 
-//     assert!(ecs.current_action(e).is_some());
-//     assert!(ecs.action_queue(e).len() == 0);
-//     assert!(ecs.world.query::<&Countdown>().iter(&mut ecs.world).count() == 1);
+    assert!(ecs.current_action(e).is_some());
+    assert!(ecs.action_queue(e).len() == 0);
+    assert!(ecs.world.query::<&Countdown>().iter(&mut ecs.world).count() == 1);
 
-//     ecs.actions(e).next();
+    ecs.actions(e).next();
 
-//     assert!(ecs.current_action(e).is_none());
-//     assert!(ecs.action_queue(e).len() == 0);
-//     assert!(ecs.world.query::<&Countdown>().iter(&mut ecs.world).count() == 0);
-// }
+    assert!(ecs.current_action(e).is_none());
+    assert!(ecs.action_queue(e).len() == 0);
+    assert!(ecs.world.query::<&Countdown>().iter(&mut ecs.world).count() == 0);
+}
 
 #[test]
 #[should_panic]
@@ -335,39 +332,39 @@ fn finish_parallel() {
     assert!(ecs.world.query::<&Countdown>().iter(&mut ecs.world).count() == 0);
 }
 
-// #[test]
-// fn finish_linked() {
-//     let mut ecs = Ecs::new();
-//     let e = ecs.spawn_agent();
+#[test]
+fn finish_linked() {
+    let mut ecs = Ecs::new();
+    let e = ecs.spawn_agent();
 
-//     ecs.actions(e).add(ActionKind::Linked(actions![
-//         CountdownAction::new(0),
-//         CountdownAction::new(0),
-//         CountdownAction::new(0),
-//     ]));
+    ecs.actions(e).add(ActionKind::Linked(actions_2d![
+        [CountdownAction::new(0)],
+        [CountdownAction::new(0)],
+        [CountdownAction::new(0)],
+    ]));
 
-//     assert!(ecs.current_action(e).is_some());
-//     assert!(ecs.action_queue(e).len() == 0);
-//     assert!(ecs.world.query::<&Countdown>().iter(&mut ecs.world).count() == 1);
+    assert!(ecs.current_action(e).is_some());
+    assert!(ecs.action_queue(e).len() == 0);
+    assert!(ecs.world.query::<&Countdown>().iter(&mut ecs.world).count() == 1);
 
-//     ecs.run();
+    ecs.run();
 
-//     assert!(ecs.current_action(e).is_some());
-//     assert!(ecs.action_queue(e).len() == 0);
-//     assert!(ecs.world.query::<&Countdown>().iter(&mut ecs.world).count() == 1);
+    assert!(ecs.current_action(e).is_some());
+    assert!(ecs.action_queue(e).len() == 0);
+    assert!(ecs.world.query::<&Countdown>().iter(&mut ecs.world).count() == 1);
 
-//     ecs.run();
+    ecs.run();
 
-//     assert!(ecs.current_action(e).is_some());
-//     assert!(ecs.action_queue(e).len() == 0);
-//     assert!(ecs.world.query::<&Countdown>().iter(&mut ecs.world).count() == 1);
+    assert!(ecs.current_action(e).is_some());
+    assert!(ecs.action_queue(e).len() == 0);
+    assert!(ecs.world.query::<&Countdown>().iter(&mut ecs.world).count() == 1);
 
-//     ecs.run();
+    ecs.run();
 
-//     assert!(ecs.current_action(e).is_none());
-//     assert!(ecs.action_queue(e).len() == 0);
-//     assert!(ecs.world.query::<&Countdown>().iter(&mut ecs.world).count() == 0);
-// }
+    assert!(ecs.current_action(e).is_none());
+    assert!(ecs.action_queue(e).len() == 0);
+    assert!(ecs.world.query::<&Countdown>().iter(&mut ecs.world).count() == 0);
+}
 
 #[test]
 fn cancel() {
@@ -407,30 +404,27 @@ fn cancel_parallel() {
     assert!(ecs.world.query::<&Countdown>().iter(&mut ecs.world).count() == 0);
 }
 
-// #[test]
-// fn cancel_linked() {
-//     let mut ecs = Ecs::new();
-//     let e = ecs.spawn_agent();
+#[test]
+fn cancel_linked() {
+    let mut ecs = Ecs::new();
+    let e = ecs.spawn_agent();
 
-//     ecs.actions(e).add(
-//         ExecutionMode::Linked,
-//         actions![
-//             CountdownAction::new(0),
-//             CountdownAction::new(0),
-//             CountdownAction::new(0),
-//         ],
-//     );
+    ecs.actions(e).add(ActionKind::Linked(actions_2d![
+        [CountdownAction::new(0)],
+        [CountdownAction::new(0)],
+        [CountdownAction::new(0)],
+    ]));
 
-//     assert!(ecs.current_action(e).is_some());
-//     assert!(ecs.action_queue(e).len() == 0);
-//     assert!(ecs.world.query::<&Countdown>().iter(&mut ecs.world).count() == 1);
+    assert!(ecs.current_action(e).is_some());
+    assert!(ecs.action_queue(e).len() == 0);
+    assert!(ecs.world.query::<&Countdown>().iter(&mut ecs.world).count() == 1);
 
-//     ecs.actions(e).cancel();
+    ecs.actions(e).cancel();
 
-//     assert!(ecs.current_action(e).is_none());
-//     assert!(ecs.action_queue(e).len() == 0);
-//     assert!(ecs.world.query::<&Countdown>().iter(&mut ecs.world).count() == 0);
-// }
+    assert!(ecs.current_action(e).is_none());
+    assert!(ecs.action_queue(e).len() == 0);
+    assert!(ecs.world.query::<&Countdown>().iter(&mut ecs.world).count() == 0);
+}
 
 #[test]
 fn pause() {
@@ -470,30 +464,27 @@ fn pause_parallel() {
     assert!(ecs.world.query::<&Countdown>().iter(&mut ecs.world).count() == 0);
 }
 
-// #[test]
-// fn pause_linked() {
-//     let mut ecs = Ecs::new();
-//     let e = ecs.spawn_agent();
+#[test]
+fn pause_linked() {
+    let mut ecs = Ecs::new();
+    let e = ecs.spawn_agent();
 
-//     ecs.actions(e).add_many(
-//         ExecutionMode::Linked,
-//         actions![
-//             CountdownAction::new(0),
-//             CountdownAction::new(0),
-//             CountdownAction::new(0),
-//         ],
-//     );
+    ecs.actions(e).add(ActionKind::Linked(actions_2d![
+        [CountdownAction::new(0)],
+        [CountdownAction::new(0)],
+        [CountdownAction::new(0)],
+    ]));
 
-//     assert!(ecs.current_action(e).is_some());
-//     assert!(ecs.action_queue(e).len() == 0);
-//     assert!(ecs.world.query::<&Countdown>().iter(&mut ecs.world).count() == 1);
+    assert!(ecs.current_action(e).is_some());
+    assert!(ecs.action_queue(e).len() == 0);
+    assert!(ecs.world.query::<&Countdown>().iter(&mut ecs.world).count() == 1);
 
-//     ecs.actions(e).pause();
+    ecs.actions(e).pause();
 
-//     assert!(ecs.current_action(e).is_none());
-//     assert!(ecs.action_queue(e).len() == 1);
-//     assert!(ecs.world.query::<&Countdown>().iter(&mut ecs.world).count() == 0);
-// }
+    assert!(ecs.current_action(e).is_none());
+    assert!(ecs.action_queue(e).len() == 1);
+    assert!(ecs.world.query::<&Countdown>().iter(&mut ecs.world).count() == 0);
+}
 
 #[test]
 #[should_panic]
@@ -616,66 +607,66 @@ fn skip_parallel() {
     assert!(ecs.action_queue(e).len() == 1);
 }
 
-// #[test]
-// fn skip_linked() {
-//     let mut ecs = Ecs::new();
-//     let e = ecs.spawn_agent();
+#[test]
+fn skip_linked() {
+    let mut ecs = Ecs::new();
+    let e = ecs.spawn_agent();
 
-//     ecs.actions(e)
-//         .config(AddConfig {
-//             order: AddOrder::Back,
-//             start: false,
-//             repeat: Repeat::None,
-//         })
-//         .add_many(
-//             ExecutionMode::Linked,
-//             actions![CountdownAction::new(0), CountdownAction::new(0)],
-//         )
-//         .config(AddConfig {
-//             order: AddOrder::Back,
-//             start: false,
-//             repeat: Repeat::Amount(1),
-//         })
-//         .add_many(
-//             ExecutionMode::Linked,
-//             actions![CountdownAction::new(0), CountdownAction::new(0)],
-//         )
-//         .config(AddConfig {
-//             order: AddOrder::Back,
-//             start: false,
-//             repeat: Repeat::Forever,
-//         })
-//         .add_many(
-//             ExecutionMode::Linked,
-//             actions![CountdownAction::new(0), CountdownAction::new(0)],
-//         );
+    ecs.actions(e)
+        .config(AddConfig {
+            order: AddOrder::Back,
+            start: false,
+            repeat: Repeat::None,
+        })
+        .add(ActionKind::Linked(actions_2d![
+            [CountdownAction::new(0)],
+            [CountdownAction::new(0)],
+        ]))
+        .config(AddConfig {
+            order: AddOrder::Back,
+            start: false,
+            repeat: Repeat::Amount(1),
+        })
+        .add(ActionKind::Linked(actions_2d![
+            [CountdownAction::new(0)],
+            [CountdownAction::new(0)],
+        ]))
+        .config(AddConfig {
+            order: AddOrder::Back,
+            start: false,
+            repeat: Repeat::Forever,
+        })
+        .add(ActionKind::Linked(actions_2d![
+            [CountdownAction::new(0)],
+            [CountdownAction::new(0)],
+        ]));
 
-//     assert!(ecs.action_queue(e).len() == 3);
+    assert!(ecs.action_queue(e).len() == 3);
 
-//     ecs.actions(e).skip();
+    ecs.actions(e).skip();
 
-//     assert!(ecs.action_queue(e).len() == 2);
+    assert!(ecs.action_queue(e).len() == 2);
 
-//     ecs.actions(e).skip();
+    ecs.actions(e).skip();
 
-//     assert!(ecs.action_queue(e).len() == 2);
+    assert!(ecs.action_queue(e).len() == 2);
 
-//     ecs.actions(e).skip();
+    ecs.actions(e).skip();
 
-//     assert!(ecs.action_queue(e).len() == 2);
+    assert!(ecs.action_queue(e).len() == 2);
 
-//     ecs.actions(e).skip();
+    ecs.actions(e).skip();
 
-//     assert!(ecs.action_queue(e).len() == 1);
+    assert!(ecs.action_queue(e).len() == 1);
 
-//     ecs.actions(e).skip();
+    ecs.actions(e).skip();
 
-//     assert!(ecs.action_queue(e).len() == 1);
+    assert!(ecs.action_queue(e).len() == 1);
 
-//     ecs.actions(e).skip();
+    ecs.actions(e).skip();
 
-//     assert!(ecs.action_queue(e).len() == 1);
-// }
+    assert!(ecs.action_queue(e).len() == 1);
+}
 
 #[test]
 fn clear() {

--- a/src/tests.rs
+++ b/src/tests.rs
@@ -202,11 +202,11 @@ fn add_many_linked() {
     let mut ecs = Ecs::new();
     let e = ecs.spawn_agent();
 
-    ecs.actions(e).add(ActionType::Linked(actions_2d![
+    ecs.actions(e).add(linked_actions![
         [CountdownAction::new(0)],
         [CountdownAction::new(0)],
         [CountdownAction::new(0)],
-    ]));
+    ]);
 
     assert!(ecs.current_action(e).is_some());
     assert!(ecs.action_queue(e).len() == 0);
@@ -219,9 +219,9 @@ fn add_many_empty() {
     let e = ecs.spawn_agent();
 
     ecs.actions(e)
-        .add(ActionType::Sequence(actions![]))
-        .add(ActionType::Parallel(actions![]))
-        .add(ActionType::Linked(actions_2d![]));
+        .add(sequential_actions![])
+        .add(parallel_actions![])
+        .add(linked_actions![]);
 
     assert!(ecs.current_action(e).is_none());
 }
@@ -269,11 +269,11 @@ fn next_linked() {
     let mut ecs = Ecs::new();
     let e = ecs.spawn_agent();
 
-    ecs.actions(e).add(ActionType::Linked(actions_2d![
+    ecs.actions(e).add(linked_actions![
         [CountdownAction::new(0)],
         [CountdownAction::new(0)],
         [CountdownAction::new(0)],
-    ]));
+    ]);
 
     assert!(ecs.current_action(e).is_some());
     assert!(ecs.action_queue(e).len() == 0);
@@ -337,11 +337,11 @@ fn finish_linked() {
     let mut ecs = Ecs::new();
     let e = ecs.spawn_agent();
 
-    ecs.actions(e).add(ActionType::Linked(actions_2d![
+    ecs.actions(e).add(linked_actions![
         [CountdownAction::new(0)],
         [CountdownAction::new(0)],
         [CountdownAction::new(0)],
-    ]));
+    ]);
 
     assert!(ecs.current_action(e).is_some());
     assert!(ecs.action_queue(e).len() == 0);
@@ -409,11 +409,11 @@ fn cancel_linked() {
     let mut ecs = Ecs::new();
     let e = ecs.spawn_agent();
 
-    ecs.actions(e).add(ActionType::Linked(actions_2d![
+    ecs.actions(e).add(linked_actions![
         [CountdownAction::new(0)],
         [CountdownAction::new(0)],
         [CountdownAction::new(0)],
-    ]));
+    ]);
 
     assert!(ecs.current_action(e).is_some());
     assert!(ecs.action_queue(e).len() == 0);
@@ -469,11 +469,11 @@ fn pause_linked() {
     let mut ecs = Ecs::new();
     let e = ecs.spawn_agent();
 
-    ecs.actions(e).add(ActionType::Linked(actions_2d![
+    ecs.actions(e).add(linked_actions![
         [CountdownAction::new(0)],
         [CountdownAction::new(0)],
         [CountdownAction::new(0)],
-    ]));
+    ]);
 
     assert!(ecs.current_action(e).is_some());
     assert!(ecs.action_queue(e).len() == 0);
@@ -618,28 +618,28 @@ fn skip_linked() {
             start: false,
             repeat: Repeat::None,
         })
-        .add(ActionType::Linked(actions_2d![
+        .add(linked_actions![
             [CountdownAction::new(0)],
             [CountdownAction::new(0)],
-        ]))
+        ])
         .config(AddConfig {
             order: AddOrder::Back,
             start: false,
             repeat: Repeat::Amount(1),
         })
-        .add(ActionType::Linked(actions_2d![
+        .add(linked_actions![
             [CountdownAction::new(0)],
             [CountdownAction::new(0)],
-        ]))
+        ])
         .config(AddConfig {
             order: AddOrder::Back,
             start: false,
             repeat: Repeat::Forever,
         })
-        .add(ActionType::Linked(actions_2d![
+        .add(linked_actions![
             [CountdownAction::new(0)],
             [CountdownAction::new(0)],
-        ]));
+        ]);
 
     assert!(ecs.action_queue(e).len() == 3);
 

--- a/src/tests.rs
+++ b/src/tests.rs
@@ -1021,3 +1021,34 @@ fn finished_exceeds_active_panic() {
 
     ecs.run();
 }
+
+macro_rules! foo {
+    ( $( $l:tt ),* $(,)? ) => {
+        Box::new([ $( bar!($l) ),* ])
+    };
+}
+
+macro_rules! bar {
+    [ $( [ $( $d:expr ),* $(,)? ] ),* $(,)? ] => {
+        Box::new([
+            $(
+                $( $d ),*
+            )*
+        ]) as Box<[_]>
+    };
+
+    ( $( $x:expr ),* $(,)? ) => {
+        Box::new( [ $( $x ),* ] )
+    };
+}
+
+#[test]
+fn test() {
+    let a = foo!(1, [3, 2], [2], [21], 22, 1, [0]);
+    for a in a.iter() {
+        print!("\t");
+        for b in a.iter() {
+            print!("{} ", b);
+        }
+    }
+}

--- a/src/tests.rs
+++ b/src/tests.rs
@@ -171,7 +171,7 @@ fn add_many_sequential() {
     let mut ecs = Ecs::new();
     let e = ecs.spawn_agent();
 
-    ecs.actions(e).add(ActionKind::Sequence(actions![
+    ecs.actions(e).add(ActionType::Sequence(actions![
         CountdownAction::new(0),
         CountdownAction::new(0),
         CountdownAction::new(0),
@@ -186,7 +186,7 @@ fn add_many_parallel() {
     let mut ecs = Ecs::new();
     let e = ecs.spawn_agent();
 
-    ecs.actions(e).add(ActionKind::Parallel(actions![
+    ecs.actions(e).add(ActionType::Parallel(actions![
         CountdownAction::new(0),
         CountdownAction::new(0),
         CountdownAction::new(0),
@@ -202,7 +202,7 @@ fn add_many_linked() {
     let mut ecs = Ecs::new();
     let e = ecs.spawn_agent();
 
-    ecs.actions(e).add(ActionKind::Linked(actions_2d![
+    ecs.actions(e).add(ActionType::Linked(actions_2d![
         [CountdownAction::new(0)],
         [CountdownAction::new(0)],
         [CountdownAction::new(0)],
@@ -219,9 +219,9 @@ fn add_many_empty() {
     let e = ecs.spawn_agent();
 
     ecs.actions(e)
-        .add(ActionKind::Sequence(actions![]))
-        .add(ActionKind::Parallel(actions![]))
-        .add(ActionKind::Linked(actions_2d![]));
+        .add(ActionType::Sequence(actions![]))
+        .add(ActionType::Parallel(actions![]))
+        .add(ActionType::Linked(actions_2d![]));
 
     assert!(ecs.current_action(e).is_none());
 }
@@ -247,7 +247,7 @@ fn next_parallel() {
     let mut ecs = Ecs::new();
     let e = ecs.spawn_agent();
 
-    ecs.actions(e).add(ActionKind::Parallel(actions![
+    ecs.actions(e).add(ActionType::Parallel(actions![
         CountdownAction::new(0),
         CountdownAction::new(0),
         CountdownAction::new(0),
@@ -269,7 +269,7 @@ fn next_linked() {
     let mut ecs = Ecs::new();
     let e = ecs.spawn_agent();
 
-    ecs.actions(e).add(ActionKind::Linked(actions_2d![
+    ecs.actions(e).add(ActionType::Linked(actions_2d![
         [CountdownAction::new(0)],
         [CountdownAction::new(0)],
         [CountdownAction::new(0)],
@@ -315,7 +315,7 @@ fn finish_parallel() {
     let mut ecs = Ecs::new();
     let e = ecs.spawn_agent();
 
-    ecs.actions(e).add(ActionKind::Parallel(actions![
+    ecs.actions(e).add(ActionType::Parallel(actions![
         CountdownAction::new(0),
         CountdownAction::new(0),
         CountdownAction::new(0),
@@ -337,7 +337,7 @@ fn finish_linked() {
     let mut ecs = Ecs::new();
     let e = ecs.spawn_agent();
 
-    ecs.actions(e).add(ActionKind::Linked(actions_2d![
+    ecs.actions(e).add(ActionType::Linked(actions_2d![
         [CountdownAction::new(0)],
         [CountdownAction::new(0)],
         [CountdownAction::new(0)],
@@ -387,7 +387,7 @@ fn cancel_parallel() {
     let mut ecs = Ecs::new();
     let e = ecs.spawn_agent();
 
-    ecs.actions(e).add(ActionKind::Parallel(actions![
+    ecs.actions(e).add(ActionType::Parallel(actions![
         CountdownAction::new(0),
         CountdownAction::new(0),
         CountdownAction::new(0),
@@ -409,7 +409,7 @@ fn cancel_linked() {
     let mut ecs = Ecs::new();
     let e = ecs.spawn_agent();
 
-    ecs.actions(e).add(ActionKind::Linked(actions_2d![
+    ecs.actions(e).add(ActionType::Linked(actions_2d![
         [CountdownAction::new(0)],
         [CountdownAction::new(0)],
         [CountdownAction::new(0)],
@@ -447,7 +447,7 @@ fn pause_parallel() {
     let mut ecs = Ecs::new();
     let e = ecs.spawn_agent();
 
-    ecs.actions(e).add(ActionKind::Parallel(actions![
+    ecs.actions(e).add(ActionType::Parallel(actions![
         CountdownAction::new(0),
         CountdownAction::new(0),
         CountdownAction::new(0),
@@ -469,7 +469,7 @@ fn pause_linked() {
     let mut ecs = Ecs::new();
     let e = ecs.spawn_agent();
 
-    ecs.actions(e).add(ActionKind::Linked(actions_2d![
+    ecs.actions(e).add(ActionType::Linked(actions_2d![
         [CountdownAction::new(0)],
         [CountdownAction::new(0)],
         [CountdownAction::new(0)],
@@ -557,7 +557,7 @@ fn skip_parallel() {
             start: false,
             repeat: Repeat::None,
         })
-        .add(ActionKind::Parallel(actions![
+        .add(ActionType::Parallel(actions![
             CountdownAction::new(0),
             CountdownAction::new(0)
         ]))
@@ -566,7 +566,7 @@ fn skip_parallel() {
             start: false,
             repeat: Repeat::Amount(1),
         })
-        .add(ActionKind::Parallel(actions![
+        .add(ActionType::Parallel(actions![
             CountdownAction::new(0),
             CountdownAction::new(0)
         ]))
@@ -575,7 +575,7 @@ fn skip_parallel() {
             start: false,
             repeat: Repeat::Forever,
         })
-        .add(ActionKind::Parallel(actions![
+        .add(ActionType::Parallel(actions![
             CountdownAction::new(0),
             CountdownAction::new(0)
         ]));
@@ -618,7 +618,7 @@ fn skip_linked() {
             start: false,
             repeat: Repeat::None,
         })
-        .add(ActionKind::Linked(actions_2d![
+        .add(ActionType::Linked(actions_2d![
             [CountdownAction::new(0)],
             [CountdownAction::new(0)],
         ]))
@@ -627,7 +627,7 @@ fn skip_linked() {
             start: false,
             repeat: Repeat::Amount(1),
         })
-        .add(ActionKind::Linked(actions_2d![
+        .add(ActionType::Linked(actions_2d![
             [CountdownAction::new(0)],
             [CountdownAction::new(0)],
         ]))
@@ -636,7 +636,7 @@ fn skip_linked() {
             start: false,
             repeat: Repeat::Forever,
         })
-        .add(ActionKind::Linked(actions_2d![
+        .add(ActionType::Linked(actions_2d![
             [CountdownAction::new(0)],
             [CountdownAction::new(0)],
         ]));
@@ -822,7 +822,7 @@ fn order() {
     let e = ecs.spawn_agent();
 
     // A, B, C
-    ecs.actions(e).add(ActionKind::Sequence(actions![
+    ecs.actions(e).add(ActionType::Sequence(actions![
         Order::<A>::default(),
         Order::<B>::default(),
         Order::<C>::default(),
@@ -846,7 +846,7 @@ fn order() {
             start: false,
             repeat: Repeat::Amount(0),
         })
-        .add(ActionKind::Sequence(actions![
+        .add(ActionType::Sequence(actions![
             Order::<A>::default(),
             Order::<B>::default(),
             Order::<C>::default(),
@@ -871,7 +871,7 @@ fn order() {
             start: false,
             repeat: Repeat::Amount(0),
         })
-        .add(ActionKind::Sequence(actions![
+        .add(ActionType::Sequence(actions![
             Order::<C>::default(),
             Order::<B>::default(),
             Order::<A>::default(),
@@ -933,7 +933,7 @@ fn reset_count() {
     let mut ecs = Ecs::new();
     let e = ecs.spawn_agent();
 
-    ecs.actions(e).add(ActionKind::Parallel(actions![
+    ecs.actions(e).add(ActionType::Parallel(actions![
         CountdownAction::new(0),
         CountdownAction::new(1),
         CountdownAction::new(2),

--- a/src/tests.rs
+++ b/src/tests.rs
@@ -179,7 +179,7 @@ fn add_many_sequential() {
     let mut ecs = Ecs::new();
     let e = ecs.spawn_agent();
 
-    ecs.actions(e).add(sequential_actions![
+    ecs.actions(e).add_sequence(actions![
         CountdownAction::new(0),
         CountdownAction::new(0),
         CountdownAction::new(0),
@@ -194,7 +194,7 @@ fn add_many_parallel() {
     let mut ecs = Ecs::new();
     let e = ecs.spawn_agent();
 
-    ecs.actions(e).add(parallel_actions![
+    ecs.actions(e).add_parallel(actions![
         CountdownAction::new(0),
         CountdownAction::new(0),
         CountdownAction::new(0),
@@ -210,11 +210,13 @@ fn add_many_linked() {
     let mut ecs = Ecs::new();
     let e = ecs.spawn_agent();
 
-    ecs.actions(e).add(linked_actions![
-        [CountdownAction::new(0)],
-        [CountdownAction::new(0)],
-        [CountdownAction::new(0)],
-    ]);
+    ecs.actions(e).add_linked(|builder| {
+        builder.add_sequence(actions![
+            CountdownAction::new(0),
+            CountdownAction::new(0),
+            CountdownAction::new(0)
+        ]);
+    });
 
     assert!(ecs.current_action(e).is_some());
     assert!(ecs.action_queue(e).len() == 0);
@@ -227,17 +229,11 @@ fn add_many_empty() {
     let e = ecs.spawn_agent();
 
     ecs.actions(e)
-        .add(sequential_actions![])
-        .add(parallel_actions![])
-        .add(linked_actions![]);
+        .add_sequence(actions![])
+        .add_parallel(actions![])
+        .add_linked(|_| {});
 
     assert!(ecs.current_action(e).is_none());
-
-    ecs.actions(e).add_linked(|builder| {
-        builder
-            .add(CountdownAction::new(0))
-            .add_sequence(actions![CountdownAction::new(0)].into_iter());
-    });
 }
 
 #[test]
@@ -261,7 +257,7 @@ fn next_parallel() {
     let mut ecs = Ecs::new();
     let e = ecs.spawn_agent();
 
-    ecs.actions(e).add(parallel_actions![
+    ecs.actions(e).add_parallel(actions![
         CountdownAction::new(0),
         CountdownAction::new(0),
         CountdownAction::new(0),
@@ -283,11 +279,13 @@ fn next_linked() {
     let mut ecs = Ecs::new();
     let e = ecs.spawn_agent();
 
-    ecs.actions(e).add(linked_actions![
-        [CountdownAction::new(0)],
-        [CountdownAction::new(0)],
-        [CountdownAction::new(0)],
-    ]);
+    ecs.actions(e).add_linked(|builder| {
+        builder.add_sequence(actions![
+            CountdownAction::new(0),
+            CountdownAction::new(0),
+            CountdownAction::new(0)
+        ]);
+    });
 
     assert!(ecs.current_action(e).is_some());
     assert!(ecs.action_queue(e).len() == 0);
@@ -329,7 +327,7 @@ fn finish_parallel() {
     let mut ecs = Ecs::new();
     let e = ecs.spawn_agent();
 
-    ecs.actions(e).add(parallel_actions![
+    ecs.actions(e).add_parallel(actions![
         CountdownAction::new(0),
         CountdownAction::new(0),
         CountdownAction::new(0),
@@ -351,11 +349,13 @@ fn finish_linked() {
     let mut ecs = Ecs::new();
     let e = ecs.spawn_agent();
 
-    ecs.actions(e).add(linked_actions![
-        [CountdownAction::new(0)],
-        [CountdownAction::new(0)],
-        [CountdownAction::new(0)],
-    ]);
+    ecs.actions(e).add_linked(|builder| {
+        builder.add_sequence(actions![
+            CountdownAction::new(0),
+            CountdownAction::new(0),
+            CountdownAction::new(0)
+        ]);
+    });
 
     assert!(ecs.current_action(e).is_some());
     assert!(ecs.action_queue(e).len() == 0);
@@ -401,7 +401,7 @@ fn cancel_parallel() {
     let mut ecs = Ecs::new();
     let e = ecs.spawn_agent();
 
-    ecs.actions(e).add(parallel_actions![
+    ecs.actions(e).add_parallel(actions![
         CountdownAction::new(0),
         CountdownAction::new(0),
         CountdownAction::new(0),
@@ -423,11 +423,13 @@ fn cancel_linked() {
     let mut ecs = Ecs::new();
     let e = ecs.spawn_agent();
 
-    ecs.actions(e).add(linked_actions![
-        [CountdownAction::new(0)],
-        [CountdownAction::new(0)],
-        [CountdownAction::new(0)],
-    ]);
+    ecs.actions(e).add_linked(|builder| {
+        builder.add_sequence(actions![
+            CountdownAction::new(0),
+            CountdownAction::new(0),
+            CountdownAction::new(0)
+        ]);
+    });
 
     assert!(ecs.current_action(e).is_some());
     assert!(ecs.action_queue(e).len() == 0);
@@ -461,7 +463,7 @@ fn pause_parallel() {
     let mut ecs = Ecs::new();
     let e = ecs.spawn_agent();
 
-    ecs.actions(e).add(parallel_actions![
+    ecs.actions(e).add_parallel(actions![
         CountdownAction::new(0),
         CountdownAction::new(0),
         CountdownAction::new(0),
@@ -483,11 +485,13 @@ fn pause_linked() {
     let mut ecs = Ecs::new();
     let e = ecs.spawn_agent();
 
-    ecs.actions(e).add(linked_actions![
-        [CountdownAction::new(0)],
-        [CountdownAction::new(0)],
-        [CountdownAction::new(0)],
-    ]);
+    ecs.actions(e).add_linked(|builder| {
+        builder.add_sequence(actions![
+            CountdownAction::new(0),
+            CountdownAction::new(0),
+            CountdownAction::new(0)
+        ]);
+    });
 
     assert!(ecs.current_action(e).is_some());
     assert!(ecs.action_queue(e).len() == 0);
@@ -571,28 +575,19 @@ fn skip_parallel() {
             start: false,
             repeat: Repeat::None,
         })
-        .add(parallel_actions![
-            CountdownAction::new(0),
-            CountdownAction::new(0)
-        ])
+        .add_parallel(actions![CountdownAction::new(0), CountdownAction::new(0)])
         .config(AddConfig {
             order: AddOrder::Back,
             start: false,
             repeat: Repeat::Amount(1),
         })
-        .add(parallel_actions![
-            CountdownAction::new(0),
-            CountdownAction::new(0)
-        ])
+        .add_parallel(actions![CountdownAction::new(0), CountdownAction::new(0)])
         .config(AddConfig {
             order: AddOrder::Back,
             start: false,
             repeat: Repeat::Forever,
         })
-        .add(parallel_actions![
-            CountdownAction::new(0),
-            CountdownAction::new(0)
-        ]);
+        .add_parallel(actions![CountdownAction::new(0), CountdownAction::new(0)]);
 
     assert!(ecs.action_queue(e).len() == 3);
 
@@ -632,28 +627,25 @@ fn skip_linked() {
             start: false,
             repeat: Repeat::None,
         })
-        .add(linked_actions![
-            [CountdownAction::new(0)],
-            [CountdownAction::new(0)],
-        ])
+        .add_linked(|builder| {
+            builder.add_sequence(actions![CountdownAction::new(0), CountdownAction::new(0)]);
+        })
         .config(AddConfig {
             order: AddOrder::Back,
             start: false,
             repeat: Repeat::Amount(1),
         })
-        .add(linked_actions![
-            [CountdownAction::new(0)],
-            [CountdownAction::new(0)],
-        ])
+        .add_linked(|builder| {
+            builder.add_sequence(actions![CountdownAction::new(0), CountdownAction::new(0)]);
+        })
         .config(AddConfig {
             order: AddOrder::Back,
             start: false,
             repeat: Repeat::Forever,
         })
-        .add(linked_actions![
-            [CountdownAction::new(0)],
-            [CountdownAction::new(0)],
-        ]);
+        .add_linked(|builder| {
+            builder.add_sequence(actions![CountdownAction::new(0), CountdownAction::new(0)]);
+        });
 
     assert!(ecs.action_queue(e).len() == 3);
 
@@ -836,7 +828,7 @@ fn order() {
     let e = ecs.spawn_agent();
 
     // A, B, C
-    ecs.actions(e).add(sequential_actions![
+    ecs.actions(e).add_sequence(actions![
         Order::<A>::default(),
         Order::<B>::default(),
         Order::<C>::default(),
@@ -860,7 +852,7 @@ fn order() {
             start: false,
             repeat: Repeat::Amount(0),
         })
-        .add(sequential_actions![
+        .add_sequence(actions![
             Order::<A>::default(),
             Order::<B>::default(),
             Order::<C>::default(),
@@ -885,7 +877,7 @@ fn order() {
             start: false,
             repeat: Repeat::Amount(0),
         })
-        .add(sequential_actions![
+        .add_sequence(actions![
             Order::<C>::default(),
             Order::<B>::default(),
             Order::<A>::default(),
@@ -947,7 +939,7 @@ fn reset_count() {
     let mut ecs = Ecs::new();
     let e = ecs.spawn_agent();
 
-    ecs.actions(e).add(parallel_actions![
+    ecs.actions(e).add_parallel(actions![
         CountdownAction::new(0),
         CountdownAction::new(1),
         CountdownAction::new(2),
@@ -998,7 +990,7 @@ fn finished_count() {
     assert!(ecs.finished_count(e) == 0);
     assert!(ecs.current_action(e).is_none());
 
-    ecs.actions(e).add(parallel_actions![
+    ecs.actions(e).add_parallel(actions![
         CountdownAction::new(0),
         CountdownAction::new(0),
         CountdownAction::new(0),
@@ -1014,10 +1006,11 @@ fn finished_count() {
     assert!(ecs.finished_count(e) == 0);
     assert!(ecs.current_action(e).is_none());
 
-    ecs.actions(e).add(linked_actions![
-        [CountdownAction::new(0)],
-        [CountdownAction::new(0), CountdownAction::new(0)],
-    ]);
+    ecs.actions(e).add_linked(|builder| {
+        builder
+            .add(CountdownAction::new(0))
+            .add_parallel(actions![CountdownAction::new(0), CountdownAction::new(0)]);
+    });
 
     ecs.run_update_only();
 

--- a/src/tests.rs
+++ b/src/tests.rs
@@ -171,11 +171,11 @@ fn add_many_sequential() {
     let mut ecs = Ecs::new();
     let e = ecs.spawn_agent();
 
-    ecs.actions(e).add(ActionType::Sequence(actions![
+    ecs.actions(e).add(sequential_actions![
         CountdownAction::new(0),
         CountdownAction::new(0),
         CountdownAction::new(0),
-    ]));
+    ]);
 
     assert!(ecs.current_action(e).is_some());
     assert!(ecs.action_queue(e).len() == 2);
@@ -186,11 +186,11 @@ fn add_many_parallel() {
     let mut ecs = Ecs::new();
     let e = ecs.spawn_agent();
 
-    ecs.actions(e).add(ActionType::Parallel(actions![
+    ecs.actions(e).add(parallel_actions![
         CountdownAction::new(0),
         CountdownAction::new(0),
         CountdownAction::new(0),
-    ]));
+    ]);
 
     assert!(ecs.current_action(e).is_some());
     assert!(ecs.action_queue(e).len() == 0);
@@ -247,11 +247,11 @@ fn next_parallel() {
     let mut ecs = Ecs::new();
     let e = ecs.spawn_agent();
 
-    ecs.actions(e).add(ActionType::Parallel(actions![
+    ecs.actions(e).add(parallel_actions![
         CountdownAction::new(0),
         CountdownAction::new(0),
         CountdownAction::new(0),
-    ]));
+    ]);
 
     assert!(ecs.current_action(e).is_some());
     assert!(ecs.action_queue(e).len() == 0);
@@ -315,11 +315,11 @@ fn finish_parallel() {
     let mut ecs = Ecs::new();
     let e = ecs.spawn_agent();
 
-    ecs.actions(e).add(ActionType::Parallel(actions![
+    ecs.actions(e).add(parallel_actions![
         CountdownAction::new(0),
         CountdownAction::new(0),
         CountdownAction::new(0),
-    ]));
+    ]);
 
     assert!(ecs.current_action(e).is_some());
     assert!(ecs.action_queue(e).len() == 0);
@@ -387,11 +387,11 @@ fn cancel_parallel() {
     let mut ecs = Ecs::new();
     let e = ecs.spawn_agent();
 
-    ecs.actions(e).add(ActionType::Parallel(actions![
+    ecs.actions(e).add(parallel_actions![
         CountdownAction::new(0),
         CountdownAction::new(0),
         CountdownAction::new(0),
-    ]));
+    ]);
 
     assert!(ecs.current_action(e).is_some());
     assert!(ecs.action_queue(e).len() == 0);
@@ -447,11 +447,11 @@ fn pause_parallel() {
     let mut ecs = Ecs::new();
     let e = ecs.spawn_agent();
 
-    ecs.actions(e).add(ActionType::Parallel(actions![
+    ecs.actions(e).add(parallel_actions![
         CountdownAction::new(0),
         CountdownAction::new(0),
         CountdownAction::new(0),
-    ]));
+    ]);
 
     assert!(ecs.current_action(e).is_some());
     assert!(ecs.action_queue(e).len() == 0);
@@ -557,28 +557,28 @@ fn skip_parallel() {
             start: false,
             repeat: Repeat::None,
         })
-        .add(ActionType::Parallel(actions![
+        .add(parallel_actions![
             CountdownAction::new(0),
             CountdownAction::new(0)
-        ]))
+        ])
         .config(AddConfig {
             order: AddOrder::Back,
             start: false,
             repeat: Repeat::Amount(1),
         })
-        .add(ActionType::Parallel(actions![
+        .add(parallel_actions![
             CountdownAction::new(0),
             CountdownAction::new(0)
-        ]))
+        ])
         .config(AddConfig {
             order: AddOrder::Back,
             start: false,
             repeat: Repeat::Forever,
         })
-        .add(ActionType::Parallel(actions![
+        .add(parallel_actions![
             CountdownAction::new(0),
             CountdownAction::new(0)
-        ]));
+        ]);
 
     assert!(ecs.action_queue(e).len() == 3);
 
@@ -822,11 +822,11 @@ fn order() {
     let e = ecs.spawn_agent();
 
     // A, B, C
-    ecs.actions(e).add(ActionType::Sequence(actions![
+    ecs.actions(e).add(sequential_actions![
         Order::<A>::default(),
         Order::<B>::default(),
         Order::<C>::default(),
-    ]));
+    ]);
 
     assert!(ecs.world.entity(e).contains::<A>());
 
@@ -846,11 +846,11 @@ fn order() {
             start: false,
             repeat: Repeat::Amount(0),
         })
-        .add(ActionType::Sequence(actions![
+        .add(sequential_actions![
             Order::<A>::default(),
             Order::<B>::default(),
             Order::<C>::default(),
-        ]))
+        ])
         .next();
 
     assert!(ecs.world.entity(e).contains::<A>());
@@ -871,11 +871,11 @@ fn order() {
             start: false,
             repeat: Repeat::Amount(0),
         })
-        .add(ActionType::Sequence(actions![
+        .add(sequential_actions![
             Order::<C>::default(),
             Order::<B>::default(),
             Order::<A>::default(),
-        ]))
+        ])
         .next();
 
     assert!(ecs.world.entity(e).contains::<C>());
@@ -933,11 +933,11 @@ fn reset_count() {
     let mut ecs = Ecs::new();
     let e = ecs.spawn_agent();
 
-    ecs.actions(e).add(ActionType::Parallel(actions![
+    ecs.actions(e).add(parallel_actions![
         CountdownAction::new(0),
         CountdownAction::new(1),
         CountdownAction::new(2),
-    ]));
+    ]);
 
     assert!(ecs.action_finished(e).reset_count == 0);
 

--- a/src/traits.rs
+++ b/src/traits.rs
@@ -79,6 +79,8 @@ pub trait ModifyActions {
 
     fn add(&mut self, action: impl Into<ActionType>) -> &mut Self;
 
+    fn add_linked(&mut self, builder: impl FnOnce(&mut LinkedActionsBuilder)) -> &mut Self;
+
     /// [`Starts`](Action::on_start) the next [`action`](Action) in the queue.
     /// Current action is [`stopped`](Action::on_stop) as [`canceled`](StopReason::Canceled).
     fn next(&mut self) -> &mut Self;

--- a/src/traits.rs
+++ b/src/traits.rs
@@ -79,9 +79,6 @@ pub trait ModifyActions {
 
     fn add(&mut self, action: impl Into<ActionKind>) -> &mut Self;
 
-    /// Adds a collection of [`actions`](Action) to the queue with the current [`config`](AddConfig).
-    fn add_many(&mut self, mode: ExecutionMode, actions: impl BoxedActionIter) -> &mut Self;
-
     /// [`Starts`](Action::on_start) the next [`action`](Action) in the queue.
     /// Current action is [`stopped`](Action::on_stop) as [`canceled`](StopReason::Canceled).
     fn next(&mut self) -> &mut Self;

--- a/src/traits.rs
+++ b/src/traits.rs
@@ -92,8 +92,9 @@ pub trait ModifyActions {
         actions: impl Iterator<Item = BoxedAction> + Send + Sync + 'static,
     ) -> &mut Self;
 
-    /// Adds a collection of linked actions to the queue that are executed sequentially.
-    /// When a linked action is either [`canceled`](Self::cancel) TODO
+    /// Adds a collection of _linked_ actions to the queue that are executed sequentially.
+    /// Being linked simply means that if any action in the collection is [`canceled`](ModifyActions::cancel),
+    /// then the remaining actions in the collection are ignored.
     fn add_linked(
         &mut self,
         f: impl FnOnce(&mut LinkedActionsBuilder) + Send + Sync + 'static,

--- a/src/traits.rs
+++ b/src/traits.rs
@@ -55,14 +55,6 @@ impl IntoBoxedAction for BoxedAction {
     }
 }
 
-/// Trait alias for a collection of actions.
-pub trait BoxedActionIter: DoubleEndedIterator<Item = BoxedAction> + Send + Sync + 'static {}
-
-impl<T> BoxedActionIter for T where
-    T: DoubleEndedIterator<Item = BoxedAction> + Send + Sync + 'static
-{
-}
-
 /// Proxy method for modifying actions. Returns a type that implements [`ModifyActions`].
 pub trait ActionsProxy<'a> {
     /// The type returned for modifying actions.

--- a/src/traits.rs
+++ b/src/traits.rs
@@ -77,7 +77,7 @@ pub trait ModifyActions {
     /// Sets the current [`config`](AddConfig) for actions to be added.
     fn config(&mut self, config: AddConfig) -> &mut Self;
 
-    fn add(&mut self, action: impl Into<ActionKind>) -> &mut Self;
+    fn add(&mut self, action: impl Into<ActionType>) -> &mut Self;
 
     /// [`Starts`](Action::on_start) the next [`action`](Action) in the queue.
     /// Current action is [`stopped`](Action::on_stop) as [`canceled`](StopReason::Canceled).

--- a/src/traits.rs
+++ b/src/traits.rs
@@ -77,18 +77,23 @@ pub trait ModifyActions {
     /// Sets the current [`config`](AddConfig) for actions to be added.
     fn config(&mut self, config: AddConfig) -> &mut Self;
 
+    /// Adds a single [`action`](Action) to the queue.
     fn add(&mut self, action: impl IntoBoxedAction) -> &mut Self;
 
+    /// Adds a collection of actions to the queue that are executed sequentially, i.e. one by one.
     fn add_sequence(
         &mut self,
         actions: impl DoubleEndedIterator<Item = BoxedAction> + Send + Sync + 'static,
     ) -> &mut Self;
 
+    /// Adds a collection of actions to the queue that are executed in parallel, i.e. all at once.
     fn add_parallel(
         &mut self,
         actions: impl Iterator<Item = BoxedAction> + Send + Sync + 'static,
     ) -> &mut Self;
 
+    /// Adds a collection of linked actions to the queue that are executed sequentially.
+    /// When a linked action is either [`canceled`](Self::cancel) TODO
     fn add_linked(
         &mut self,
         f: impl FnOnce(&mut LinkedActionsBuilder) + Send + Sync + 'static,

--- a/src/traits.rs
+++ b/src/traits.rs
@@ -93,7 +93,7 @@ pub trait ModifyActions {
     ) -> &mut Self;
 
     /// Adds a collection of _linked_ actions to the queue that are executed sequentially.
-    /// Being linked simply means that if any action in the collection is [`canceled`](ModifyActions::cancel),
+    /// Linked actions have the property that if any of them are [`canceled`](ModifyActions::cancel),
     /// then the remaining actions in the collection are ignored.
     fn add_linked(
         &mut self,

--- a/src/traits.rs
+++ b/src/traits.rs
@@ -77,9 +77,22 @@ pub trait ModifyActions {
     /// Sets the current [`config`](AddConfig) for actions to be added.
     fn config(&mut self, config: AddConfig) -> &mut Self;
 
-    fn add(&mut self, action: impl Into<ActionType>) -> &mut Self;
+    fn add(&mut self, action: impl IntoBoxedAction) -> &mut Self;
 
-    fn add_linked(&mut self, builder: impl FnOnce(&mut LinkedActionsBuilder)) -> &mut Self;
+    fn add_sequence(
+        &mut self,
+        actions: impl DoubleEndedIterator<Item = BoxedAction> + Send + Sync + 'static,
+    ) -> &mut Self;
+
+    fn add_parallel(
+        &mut self,
+        actions: impl Iterator<Item = BoxedAction> + Send + Sync + 'static,
+    ) -> &mut Self;
+
+    fn add_linked(
+        &mut self,
+        f: impl FnOnce(&mut LinkedActionsBuilder) + Send + Sync + 'static,
+    ) -> &mut Self;
 
     /// [`Starts`](Action::on_start) the next [`action`](Action) in the queue.
     /// Current action is [`stopped`](Action::on_stop) as [`canceled`](StopReason::Canceled).

--- a/src/traits.rs
+++ b/src/traits.rs
@@ -77,8 +77,7 @@ pub trait ModifyActions {
     /// Sets the current [`config`](AddConfig) for actions to be added.
     fn config(&mut self, config: AddConfig) -> &mut Self;
 
-    /// Adds an [`action`](Action) to the queue with the current [`config`](AddConfig).
-    fn add(&mut self, action: impl IntoBoxedAction) -> &mut Self;
+    fn add(&mut self, action: impl Into<ActionKind>) -> &mut Self;
 
     /// Adds a collection of [`actions`](Action) to the queue with the current [`config`](AddConfig).
     fn add_many(&mut self, mode: ExecutionMode, actions: impl BoxedActionIter) -> &mut Self;

--- a/src/world.rs
+++ b/src/world.rs
@@ -267,10 +267,15 @@ impl WorldActionsExt for World {
         if let Some((mut next_action, repeat)) = self.pop_next_action(agent) {
             let mut commands = ActionCommands::new();
 
-            // TODO
-            // for action in next_action.iter_mut() {
-            //     action.on_start(agent, self, &mut commands);
-            // }
+            match &mut next_action {
+                ActionType::Single(action) => action.on_start(agent, self, &mut commands),
+                ActionType::Parallel(actions) => actions
+                    .iter_mut()
+                    .for_each(|action| action.on_start(agent, self, &mut commands)),
+                ActionType::Linked(actions, index) => {
+                    actions[*index].on_start(agent, self, &mut commands)
+                }
+            }
 
             self.get_mut::<CurrentAction>(agent).unwrap().0 = Some((next_action, repeat));
 

--- a/src/world.rs
+++ b/src/world.rs
@@ -72,7 +72,7 @@ impl ModifyActionsWorldExt for World {
             ActionType::Single(action) => {
                 self.action_queue(agent).push(
                     config.order,
-                    (InternalActionType::Single(action), config.repeat),
+                    (ActionTypeInternal::One(action), config.repeat),
                 );
             }
             ActionType::Sequence(actions) => {
@@ -81,12 +81,12 @@ impl ModifyActionsWorldExt for World {
                 match config.order {
                     AddOrder::Back => {
                         for action in actions {
-                            queue.push_back((InternalActionType::Single(action), config.repeat));
+                            queue.push_back((ActionTypeInternal::One(action), config.repeat));
                         }
                     }
                     AddOrder::Front => {
                         for action in actions.rev() {
-                            queue.push_front((InternalActionType::Single(action), config.repeat));
+                            queue.push_front((ActionTypeInternal::One(action), config.repeat));
                         }
                     }
                 }
@@ -97,7 +97,7 @@ impl ModifyActionsWorldExt for World {
                 if !actions.is_empty() {
                     self.action_queue(agent).push(
                         config.order,
-                        (InternalActionType::Parallel(actions), config.repeat),
+                        (ActionTypeInternal::Many(actions), config.repeat),
                     );
                 }
             }
@@ -107,7 +107,7 @@ impl ModifyActionsWorldExt for World {
                 if !actions.is_empty() {
                     self.action_queue(agent).push(
                         config.order,
-                        (InternalActionType::Linked(actions, 0), config.repeat),
+                        (ActionTypeInternal::Linked(actions, 0), config.repeat),
                     );
                 }
             }
@@ -169,7 +169,7 @@ impl WorldActionsExt for World {
                 .reset_counts();
 
             match &mut current_action {
-                InternalActionType::Single(action) => {
+                ActionTypeInternal::One(action) => {
                     action.on_stop(agent, self, reason);
 
                     match reason {
@@ -184,7 +184,7 @@ impl WorldActionsExt for World {
                         }
                     }
                 }
-                InternalActionType::Parallel(actions) => {
+                ActionTypeInternal::Many(actions) => {
                     actions
                         .iter_mut()
                         .for_each(|action| action.on_stop(agent, self, reason));
@@ -201,7 +201,7 @@ impl WorldActionsExt for World {
                         }
                     }
                 }
-                InternalActionType::Linked(actions, index) => {
+                ActionTypeInternal::Linked(actions, index) => {
                     for action in actions[*index].iter_mut() {
                         action.on_stop(agent, self, reason);
                     }
@@ -239,11 +239,11 @@ impl WorldActionsExt for World {
             let mut commands = ActionCommands::new();
 
             match &mut next_action {
-                InternalActionType::Single(action) => action.on_start(agent, self, &mut commands),
-                InternalActionType::Parallel(actions) => actions
+                ActionTypeInternal::One(action) => action.on_start(agent, self, &mut commands),
+                ActionTypeInternal::Many(actions) => actions
                     .iter_mut()
                     .for_each(|action| action.on_start(agent, self, &mut commands)),
-                InternalActionType::Linked(actions, index) => {
+                ActionTypeInternal::Linked(actions, index) => {
                     for action in actions[*index].iter_mut() {
                         action.on_start(agent, self, &mut commands)
                     }

--- a/src/world.rs
+++ b/src/world.rs
@@ -240,11 +240,12 @@ impl WorldActionsExt for World {
                         StopReason::Finished => {
                             *index += 1;
 
-                            if *index == actions.len() {
-                                if repeat.process() {
-                                    *index = 0;
-                                    self.action_queue(agent).push_back((current_action, repeat));
-                                }
+                            if *index < actions.len() {
+                                self.action_queue(agent)
+                                    .push_front((current_action, repeat));
+                            } else if *index == actions.len() && repeat.process() {
+                                *index = 0;
+                                self.action_queue(agent).push_back((current_action, repeat));
                             }
                         }
                         StopReason::Canceled => {

--- a/src/world.rs
+++ b/src/world.rs
@@ -58,13 +58,6 @@ impl ModifyActions for AgentWorldActions<'_> {
 
 pub(super) trait ModifyActionsWorldExt {
     fn add_action(&mut self, agent: Entity, config: AddConfig, action: impl Into<ActionKind>);
-    fn add_actions(
-        &mut self,
-        agent: Entity,
-        config: AddConfig,
-        mode: ExecutionMode,
-        actions: impl BoxedActionIter,
-    );
     fn next_action(&mut self, agent: Entity);
     fn finish_action(&mut self, agent: Entity);
     fn cancel_action(&mut self, agent: Entity);
@@ -136,63 +129,6 @@ impl ModifyActionsWorldExt for World {
         if config.start && !self.has_current_action(agent) {
             self.start_next_action(agent);
         }
-    }
-
-    fn add_actions(
-        &mut self,
-        agent: Entity,
-        config: AddConfig,
-        mode: ExecutionMode,
-        actions: impl BoxedActionIter,
-    ) {
-        // TODO: Remove
-        // let mut queue = self.action_queue(agent);
-
-        // match mode {
-        //     ExecutionMode::Sequential => match config.order {
-        //         AddOrder::Back => {
-        //             for action in actions {
-        //                 queue.push_back((ActionType::Single(action), config.repeat));
-        //             }
-        //         }
-        //         AddOrder::Front => {
-        //             for action in actions.rev() {
-        //                 queue.push_front((ActionType::Single(action), config.repeat));
-        //             }
-        //         }
-        //     },
-        //     ExecutionMode::Parallel => {
-        //         let actions = actions.collect::<Box<[_]>>();
-        //         if !actions.is_empty() {
-        //             match config.order {
-        //                 AddOrder::Back => {
-        //                     queue.push_back((ActionType::Parallel(actions), config.repeat));
-        //                 }
-        //                 AddOrder::Front => {
-        //                     queue.push_front((ActionType::Parallel(actions), config.repeat));
-        //                 }
-        //             }
-        //         }
-        //     }
-        //     ExecutionMode::Linked => match config.order {
-        //         AddOrder::Back => {
-        //             let actions = actions.collect::<Box<[_]>>();
-        //             if !actions.is_empty() {
-        //                 queue.push_back((ActionType::Linked(actions, 0), config.repeat));
-        //             }
-        //         }
-        //         AddOrder::Front => {
-        //             let actions = actions.rev().collect::<Box<[_]>>();
-        //             if !actions.is_empty() {
-        //                 queue.push_front((ActionType::Linked(actions, 0), config.repeat));
-        //             }
-        //         }
-        //     },
-        // }
-
-        // if config.start && !self.has_current_action(agent) {
-        //     self.start_next_action(agent);
-        // }
     }
 
     fn next_action(&mut self, agent: Entity) {

--- a/src/world.rs
+++ b/src/world.rs
@@ -30,12 +30,6 @@ impl ModifyActions for AgentWorldActions<'_> {
         self
     }
 
-    fn add_many(&mut self, mode: ExecutionMode, actions: impl BoxedActionIter) -> &mut Self {
-        self.world
-            .add_actions(self.agent, self.config, mode, actions);
-        self
-    }
-
     fn next(&mut self) -> &mut Self {
         self.world.next_action(self.agent);
         self

--- a/src/world.rs
+++ b/src/world.rs
@@ -32,16 +32,19 @@ impl ModifyActions for AgentWorldActions<'_> {
 
     fn add_sequence(
         &mut self,
-        actions: impl Iterator<Item = BoxedAction> + Send + Sync + 'static,
+        actions: impl DoubleEndedIterator<Item = BoxedAction> + Send + Sync + 'static,
     ) -> &mut Self {
-        todo!()
+        self.world.add_actions(self.agent, self.config, actions);
+        self
     }
 
     fn add_parallel(
         &mut self,
         actions: impl Iterator<Item = BoxedAction> + Send + Sync + 'static,
     ) -> &mut Self {
-        todo!()
+        self.world
+            .add_parallel_actions(self.agent, self.config, actions);
+        self
     }
 
     fn add_linked(

--- a/src/world.rs
+++ b/src/world.rs
@@ -112,16 +112,22 @@ impl ModifyActionsWorldExt for World {
                 }
             }
             ActionType::Linked(actions) => {
-                let mut queue = self.action_queue(agent);
+                let actions = actions.filter(|a| !a.is_empty()).collect::<Box<[_]>>();
 
-                // TODO: what if empty?
+                if !actions.is_empty() {
+                    let mut queue = self.action_queue(agent);
 
-                match config.order {
-                    AddOrder::Back => {
-                        queue.push_back((InternalActionType::Linked(actions, 0), config.repeat));
-                    }
-                    AddOrder::Front => {
-                        queue.push_front((InternalActionType::Linked(actions, 0), config.repeat));
+                    match config.order {
+                        AddOrder::Back => {
+                            queue
+                                .push_back((InternalActionType::Linked(actions, 0), config.repeat));
+                        }
+                        AddOrder::Front => {
+                            queue.push_front((
+                                InternalActionType::Linked(actions, 0),
+                                config.repeat,
+                            ));
+                        }
                     }
                 }
             }

--- a/src/world.rs
+++ b/src/world.rs
@@ -108,6 +108,8 @@ impl ModifyActionsWorldExt for World {
                 }
             }
             ActionKind::Parallel(actions) => {
+                let actions = actions.collect::<Box<_>>();
+
                 if !actions.is_empty() {
                     let mut queue = self.action_queue(agent);
 

--- a/src/world.rs
+++ b/src/world.rs
@@ -30,6 +30,10 @@ impl ModifyActions for AgentWorldActions<'_> {
         self
     }
 
+    fn add_linked(&mut self, builder: impl FnOnce(&mut LinkedActionsBuilder)) -> &mut Self {
+        todo!()
+    }
+
     fn next(&mut self) -> &mut Self {
         self.world.next_action(self.agent);
         self
@@ -58,6 +62,12 @@ impl ModifyActions for AgentWorldActions<'_> {
 
 pub(super) trait ModifyActionsWorldExt {
     fn add_action(&mut self, agent: Entity, config: AddConfig, action: impl Into<ActionType>);
+    fn add_linked(
+        &mut self,
+        agent: Entity,
+        config: AddConfig,
+        actions: impl FnOnce(&mut LinkedActionsBuilder),
+    );
     fn next_action(&mut self, agent: Entity);
     fn finish_action(&mut self, agent: Entity);
     fn cancel_action(&mut self, agent: Entity);
@@ -116,6 +126,15 @@ impl ModifyActionsWorldExt for World {
         if config.start && !self.has_current_action(agent) {
             self.start_next_action(agent);
         }
+    }
+
+    fn add_linked(
+        &mut self,
+        agent: Entity,
+        config: AddConfig,
+        actions: impl FnOnce(&mut LinkedActionsBuilder),
+    ) {
+        todo!()
     }
 
     fn next_action(&mut self, agent: Entity) {

--- a/src/world.rs
+++ b/src/world.rs
@@ -70,13 +70,10 @@ impl ModifyActionsWorldExt for World {
     fn add_action(&mut self, agent: Entity, config: AddConfig, action: impl Into<ActionType>) {
         match Into::<ActionType>::into(action) {
             ActionType::Single(action) => {
-                let tuple = (InternalActionType::Single(action), config.repeat);
-                let mut queue = self.action_queue(agent);
-
-                match config.order {
-                    AddOrder::Back => queue.push_back(tuple),
-                    AddOrder::Front => queue.push_front(tuple),
-                }
+                self.action_queue(agent).push(
+                    config.order,
+                    (InternalActionType::Single(action), config.repeat),
+                );
             }
             ActionType::Sequence(actions) => {
                 let mut queue = self.action_queue(agent);
@@ -98,37 +95,20 @@ impl ModifyActionsWorldExt for World {
                 let actions = actions.collect::<Box<_>>();
 
                 if !actions.is_empty() {
-                    let mut queue = self.action_queue(agent);
-
-                    match config.order {
-                        AddOrder::Back => {
-                            queue.push_back((InternalActionType::Parallel(actions), config.repeat));
-                        }
-                        AddOrder::Front => {
-                            queue
-                                .push_front((InternalActionType::Parallel(actions), config.repeat));
-                        }
-                    }
+                    self.action_queue(agent).push(
+                        config.order,
+                        (InternalActionType::Parallel(actions), config.repeat),
+                    );
                 }
             }
             ActionType::Linked(actions) => {
                 let actions = actions.filter(|a| !a.is_empty()).collect::<Box<[_]>>();
 
                 if !actions.is_empty() {
-                    let mut queue = self.action_queue(agent);
-
-                    match config.order {
-                        AddOrder::Back => {
-                            queue
-                                .push_back((InternalActionType::Linked(actions, 0), config.repeat));
-                        }
-                        AddOrder::Front => {
-                            queue.push_front((
-                                InternalActionType::Linked(actions, 0),
-                                config.repeat,
-                            ));
-                        }
-                    }
+                    self.action_queue(agent).push(
+                        config.order,
+                        (InternalActionType::Linked(actions, 0), config.repeat),
+                    );
                 }
             }
         }

--- a/src/world.rs
+++ b/src/world.rs
@@ -83,7 +83,7 @@ impl ModifyActionsWorldExt for World {
     fn add_action(&mut self, agent: Entity, config: AddConfig, action: impl Into<ActionKind>) {
         match Into::<ActionKind>::into(action) {
             ActionKind::Single(action) => {
-                let tuple = (ActionType::Single(action.into_boxed()), config.repeat);
+                let tuple = (ActionType::Single(action), config.repeat);
                 let mut queue = self.action_queue(agent);
 
                 match config.order {

--- a/src/world.rs
+++ b/src/world.rs
@@ -117,7 +117,20 @@ impl ModifyActionsWorldExt for World {
                     }
                 }
             }
-            ActionKind::Linked(_) => todo!(),
+            ActionKind::Linked(actions) => {
+                let mut queue = self.action_queue(agent);
+
+                // TODO: what if empty?
+
+                match config.order {
+                    AddOrder::Back => {
+                        queue.push_back((ActionType::Linked(actions, 0), config.repeat));
+                    }
+                    AddOrder::Front => {
+                        queue.push_front((ActionType::Linked(actions, 0), config.repeat));
+                    }
+                }
+            }
         }
 
         if config.start && !self.has_current_action(agent) {

--- a/src/world.rs
+++ b/src/world.rs
@@ -132,53 +132,54 @@ impl ModifyActionsWorldExt for World {
         mode: ExecutionMode,
         actions: impl BoxedActionIter,
     ) {
-        let mut queue = self.action_queue(agent);
+        // TODO: Remove
+        // let mut queue = self.action_queue(agent);
 
-        match mode {
-            ExecutionMode::Sequential => match config.order {
-                AddOrder::Back => {
-                    for action in actions {
-                        queue.push_back((ActionType::Single(action), config.repeat));
-                    }
-                }
-                AddOrder::Front => {
-                    for action in actions.rev() {
-                        queue.push_front((ActionType::Single(action), config.repeat));
-                    }
-                }
-            },
-            ExecutionMode::Parallel => {
-                let actions = actions.collect::<Box<[_]>>();
-                if !actions.is_empty() {
-                    match config.order {
-                        AddOrder::Back => {
-                            queue.push_back((ActionType::Parallel(actions), config.repeat));
-                        }
-                        AddOrder::Front => {
-                            queue.push_front((ActionType::Parallel(actions), config.repeat));
-                        }
-                    }
-                }
-            }
-            ExecutionMode::Linked => match config.order {
-                AddOrder::Back => {
-                    let actions = actions.collect::<Box<[_]>>();
-                    if !actions.is_empty() {
-                        queue.push_back((ActionType::Linked(actions, 0), config.repeat));
-                    }
-                }
-                AddOrder::Front => {
-                    let actions = actions.rev().collect::<Box<[_]>>();
-                    if !actions.is_empty() {
-                        queue.push_front((ActionType::Linked(actions, 0), config.repeat));
-                    }
-                }
-            },
-        }
+        // match mode {
+        //     ExecutionMode::Sequential => match config.order {
+        //         AddOrder::Back => {
+        //             for action in actions {
+        //                 queue.push_back((ActionType::Single(action), config.repeat));
+        //             }
+        //         }
+        //         AddOrder::Front => {
+        //             for action in actions.rev() {
+        //                 queue.push_front((ActionType::Single(action), config.repeat));
+        //             }
+        //         }
+        //     },
+        //     ExecutionMode::Parallel => {
+        //         let actions = actions.collect::<Box<[_]>>();
+        //         if !actions.is_empty() {
+        //             match config.order {
+        //                 AddOrder::Back => {
+        //                     queue.push_back((ActionType::Parallel(actions), config.repeat));
+        //                 }
+        //                 AddOrder::Front => {
+        //                     queue.push_front((ActionType::Parallel(actions), config.repeat));
+        //                 }
+        //             }
+        //         }
+        //     }
+        //     ExecutionMode::Linked => match config.order {
+        //         AddOrder::Back => {
+        //             let actions = actions.collect::<Box<[_]>>();
+        //             if !actions.is_empty() {
+        //                 queue.push_back((ActionType::Linked(actions, 0), config.repeat));
+        //             }
+        //         }
+        //         AddOrder::Front => {
+        //             let actions = actions.rev().collect::<Box<[_]>>();
+        //             if !actions.is_empty() {
+        //                 queue.push_front((ActionType::Linked(actions, 0), config.repeat));
+        //             }
+        //         }
+        //     },
+        // }
 
-        if config.start && !self.has_current_action(agent) {
-            self.start_next_action(agent);
-        }
+        // if config.start && !self.has_current_action(agent) {
+        //     self.start_next_action(agent);
+        // }
     }
 
     fn next_action(&mut self, agent: Entity) {
@@ -265,7 +266,9 @@ impl WorldActionsExt for World {
                     }
                 }
                 ActionType::Linked(actions, index) => {
-                    actions[*index].on_stop(agent, self, reason);
+                    for action in actions[*index].iter_mut() {
+                        action.on_stop(agent, self, reason);
+                    }
 
                     match reason {
                         StopReason::Finished => {
@@ -305,7 +308,9 @@ impl WorldActionsExt for World {
                     .iter_mut()
                     .for_each(|action| action.on_start(agent, self, &mut commands)),
                 ActionType::Linked(actions, index) => {
-                    actions[*index].on_start(agent, self, &mut commands)
+                    for action in actions[*index].iter_mut() {
+                        action.on_start(agent, self, &mut commands)
+                    }
                 }
             }
 

--- a/src/world.rs
+++ b/src/world.rs
@@ -30,8 +30,14 @@ impl ModifyActions for AgentWorldActions<'_> {
         self
     }
 
-    fn add_linked(&mut self, builder: impl FnOnce(&mut LinkedActionsBuilder)) -> &mut Self {
-        todo!()
+    fn add_linked(&mut self, f: impl FnOnce(&mut LinkedActionsBuilder)) -> &mut Self {
+        let mut actions = LinkedActionsBuilder::new();
+        f(&mut actions);
+
+        self.world
+            .add_linked_actions(self.agent, self.config, actions);
+
+        self
     }
 
     fn next(&mut self) -> &mut Self {
@@ -62,11 +68,11 @@ impl ModifyActions for AgentWorldActions<'_> {
 
 pub(super) trait ModifyActionsWorldExt {
     fn add_action(&mut self, agent: Entity, config: AddConfig, action: impl Into<ActionType>);
-    fn add_linked(
+    fn add_linked_actions(
         &mut self,
         agent: Entity,
         config: AddConfig,
-        actions: impl FnOnce(&mut LinkedActionsBuilder),
+        actions: LinkedActionsBuilder,
     );
     fn next_action(&mut self, agent: Entity);
     fn finish_action(&mut self, agent: Entity);
@@ -128,13 +134,17 @@ impl ModifyActionsWorldExt for World {
         }
     }
 
-    fn add_linked(
+    fn add_linked_actions(
         &mut self,
         agent: Entity,
         config: AddConfig,
-        actions: impl FnOnce(&mut LinkedActionsBuilder),
+        actions: LinkedActionsBuilder,
     ) {
-        todo!()
+        let actions = actions.build();
+
+        if !actions.is_empty() {
+            todo!()
+        }
     }
 
     fn next_action(&mut self, agent: Entity) {


### PR DESCRIPTION
This PR adds _linked_ actions — a collection of actions executed sequentially, but with the property that if any of them are canceled, then the remaining actions in the collection are ignored.

```rust
commands
    .actions(agent)
    .add_linked(|builder| {
        builder
            .add(a)
            .add_parallel(actions![b, c]);
    })
    .add(d);
```

In the example above, a collection of linked actions have been added. The action `a` will run first, and then both `b` and `c` in parallel. When done, the queue will advance to action `d`. However, let's say action `a` is currently running, and the `commands.actions(agent).cancel()` method has been called. What follows then is that the `on_stop` method will be called for action `a`, and the action queue will advance directly to action `d`. The remaining linked actions (`b` and `c` in parallel) are simply ignored. This is what linked actions are.

This PR also replaces the `add_many` method with `add_sequence` and `add_parallel` for consistency with the new `add_linked` method.

```rust
// old
commands
    .actions(agent)
    .add_many(ExecutionMode::Sequential, actions![a, b, c])
    .add_many(ExecutionMode::Parallel, actions![d, e, f]);

// new
commands
    .actions(agent)
    .add_sequence(actions![a, b, c])
    .add_parallel(actions![d, e, f]);
```