### PR TITLE
Replace `config` with `start`, `order` and `repeat` methods

### DIFF
--- a/README.md
+++ b/README.md
@@ -40,14 +40,9 @@ fn setup(mut commands: Commands) {
     // Add multiple actions with custom config
     commands
         .actions(agent)
-        .config(AddConfig {
-            // Add each action to the back of the queue
-            order: AddOrder::Back,
-            // Start the next action if nothing is currently running
-            start: true,
-            // Repeat the action
-            repeat: Repeat::None,
-        })
+        .start(true) // Start the next action if nothing is currently running
+        .order(AddOrder::Back) // Add each action to the back of the queue
+        .repeat(Repeat::None) // Repeat the action
         .add(action_b)
         .add(action_c);
 

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -3,6 +3,7 @@
 ## Version 0.7.0-dev
 
 - [Add linked actions][63]
+- [Replace `config` with `start`, `order` and `repeat` methods][64]
 
 ## Version 0.6.0
 
@@ -42,6 +43,7 @@
 
 First release! 🎉
 
+[64]: https://github.com/hikikones/bevy-sequential-actions/pull/64
 [63]: https://github.com/hikikones/bevy-sequential-actions/pull/63
 [55]: https://github.com/hikikones/bevy-sequential-actions/pull/55
 [53]: https://github.com/hikikones/bevy-sequential-actions/pull/53

--- a/examples/basic.rs
+++ b/examples/basic.rs
@@ -26,14 +26,12 @@ fn setup(mut commands: Commands) {
     // Add multiple actions with custom config
     commands
         .actions(agent)
-        .config(AddConfig {
-            // Add each action to the back of the queue
-            order: AddOrder::Back,
-            // Start the next action if nothing is currently running
-            start: true,
-            // Repeat the action
-            repeat: Repeat::None,
-        })
+        // Start the next action if nothing is currently running
+        .start(true)
+        // Add each action to the back of the queue
+        .order(AddOrder::Back)
+        // Repeat the action
+        .repeat(Repeat::None)
         .add(MoveAction::new(MoveConfig {
             target: -Vec3::X * 2.0,
             speed: 4.0,
@@ -50,11 +48,8 @@ fn setup(mut commands: Commands) {
     // Add a collection of actions
     commands
         .actions(agent)
-        .config(AddConfig {
-            // This time, add each action to the front of the queue
-            order: AddOrder::Front,
-            ..Default::default()
-        })
+        // This time, add each action to the front of the queue
+        .order(AddOrder::Front)
         .add_sequence(actions![
             WaitAction::new(10.0),
             WaitAction::new(100.0),
@@ -109,11 +104,8 @@ impl Action for MyCustomAction {
 
         commands
             .actions(agent)
-            .config(AddConfig {
-                order: AddOrder::Front,
-                start: false,
-                repeat: Repeat::None,
-            })
+            .start(false)
+            .order(AddOrder::Front)
             .add_sequence(actions![
                 LerpAction::new(LerpConfig {
                     target: camera,
@@ -166,9 +158,6 @@ fn my_system(agent_q: Query<Entity, With<Agent>>, mut commands: Commands) {
     let agent = agent_q.single();
     commands
         .actions(agent)
-        .config(AddConfig {
-            order: AddOrder::Front,
-            ..Default::default()
-        })
+        .order(AddOrder::Front)
         .add(WaitAction::new(1.0));
 }

--- a/examples/parallel.rs
+++ b/examples/parallel.rs
@@ -18,11 +18,7 @@ fn setup(mut commands: Commands, camera_q: Query<Entity, With<CameraPivot>>) {
 
     commands
         .actions(agent)
-        .config(AddConfig {
-            order: AddOrder::Back,
-            start: true,
-            repeat: Repeat::Forever,
-        })
+        .repeat(Repeat::Forever)
         .add(WaitAction::new(1.0))
         .add_parallel(actions![
             MoveAction::new(MoveConfig {

--- a/examples/pause.rs
+++ b/examples/pause.rs
@@ -26,11 +26,7 @@ fn setup(mut commands: Commands) {
 
         commands
             .actions(agent)
-            .config(AddConfig {
-                order: AddOrder::Back,
-                start: true,
-                repeat: Repeat::Forever,
-            })
+            .repeat(Repeat::Forever)
             .add(WaitAction::new(seconds))
             .add(RotateAction::new(RotateConfig {
                 target: RotateType::Euler(rotation),

--- a/examples/repeat.rs
+++ b/examples/repeat.rs
@@ -33,11 +33,7 @@ fn setup(mut commands: Commands) {
 
         commands
             .actions(agent)
-            .config(AddConfig {
-                order: AddOrder::Back,
-                start: true,
-                repeat,
-            })
+            .repeat(repeat)
             .add(WaitAction::new(0.5))
             .add(MoveAction::new(MoveConfig {
                 target: end,

--- a/src/action_commands.rs
+++ b/src/action_commands.rs
@@ -29,7 +29,7 @@ impl<'a> ActionsProxy<'a> for ActionCommands {
     fn actions(&'a mut self, agent: Entity) -> AgentActions<'a> {
         AgentActions {
             agent,
-            config: AddConfig::default(),
+            config: AddConfig::new(),
             commands: self,
         }
     }

--- a/src/action_commands.rs
+++ b/src/action_commands.rs
@@ -43,6 +43,21 @@ pub struct AgentActions<'a> {
 }
 
 impl ModifyActions for AgentActions<'_> {
+    fn start(&mut self, start: bool) -> &mut Self {
+        self.config.start = start;
+        self
+    }
+
+    fn order(&mut self, order: AddOrder) -> &mut Self {
+        self.config.order = order;
+        self
+    }
+
+    fn repeat(&mut self, repeat: Repeat) -> &mut Self {
+        self.config.repeat = repeat;
+        self
+    }
+
     fn config(&mut self, config: AddConfig) -> &mut Self {
         self.config = config;
         self

--- a/src/action_commands.rs
+++ b/src/action_commands.rs
@@ -58,11 +58,6 @@ impl ModifyActions for AgentActions<'_> {
         self
     }
 
-    fn config(&mut self, config: AddConfig) -> &mut Self {
-        self.config = config;
-        self
-    }
-
     fn add(&mut self, action: impl IntoBoxedAction) -> &mut Self {
         let agent = self.agent;
         let config = self.config;

--- a/src/commands.rs
+++ b/src/commands.rs
@@ -20,6 +20,21 @@ pub struct AgentCommandsActions<'c, 'w, 's> {
 }
 
 impl ModifyActions for AgentCommandsActions<'_, '_, '_> {
+    fn start(&mut self, start: bool) -> &mut Self {
+        self.config.start = start;
+        self
+    }
+
+    fn order(&mut self, order: AddOrder) -> &mut Self {
+        self.config.order = order;
+        self
+    }
+
+    fn repeat(&mut self, repeat: Repeat) -> &mut Self {
+        self.config.repeat = repeat;
+        self
+    }
+
     fn config(&mut self, config: AddConfig) -> &mut Self {
         self.config = config;
         self

--- a/src/commands.rs
+++ b/src/commands.rs
@@ -35,11 +35,6 @@ impl ModifyActions for AgentCommandsActions<'_, '_, '_> {
         self
     }
 
-    fn config(&mut self, config: AddConfig) -> &mut Self {
-        self.config = config;
-        self
-    }
-
     fn add(&mut self, action: impl IntoBoxedAction) -> &mut Self {
         let agent = self.agent;
         let config = self.config;

--- a/src/commands.rs
+++ b/src/commands.rs
@@ -6,7 +6,7 @@ impl<'c, 'w: 'c, 's: 'c> ActionsProxy<'c> for Commands<'w, 's> {
     fn actions(&'c mut self, agent: Entity) -> AgentCommandsActions<'c, 'w, 's> {
         AgentCommandsActions {
             agent,
-            config: AddConfig::default(),
+            config: AddConfig::new(),
             commands: self,
         }
     }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -313,8 +313,8 @@ struct AddConfig {
     repeat: Repeat,
 }
 
-impl Default for AddConfig {
-    fn default() -> Self {
+impl AddConfig {
+    const fn new() -> Self {
         Self {
             order: AddOrder::Back,
             start: true,

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -197,8 +197,8 @@ mod plugin;
 mod traits;
 mod world;
 
-#[cfg(test)]
-mod tests;
+// #[cfg(test)]
+// mod tests;
 
 pub use action_commands::*;
 pub use commands::*;
@@ -258,27 +258,6 @@ impl ActionFinished {
     }
 }
 
-/// Configuration for an [`Action`] to be added.
-#[derive(Clone, Copy)]
-pub struct AddConfig {
-    /// Specify the queue order for the [`action`](Action) to be added.
-    pub order: AddOrder,
-    /// Start the next [`action`](Action) in the queue if nothing is currently running.
-    pub start: bool,
-    /// Specify how many times the [`action`](Action) should be repeated.
-    pub repeat: Repeat,
-}
-
-impl Default for AddConfig {
-    fn default() -> Self {
-        Self {
-            order: AddOrder::Back,
-            start: true,
-            repeat: Repeat::None,
-        }
-    }
-}
-
 /// The queue order for an [`Action`] to be added.
 #[derive(Clone, Copy)]
 pub enum AddOrder {
@@ -325,6 +304,23 @@ pub enum StopReason {
     Canceled,
     /// The [`action`](Action) was paused.
     Paused,
+}
+
+#[derive(Clone, Copy)]
+struct AddConfig {
+    order: AddOrder,
+    start: bool,
+    repeat: Repeat,
+}
+
+impl Default for AddConfig {
+    fn default() -> Self {
+        Self {
+            order: AddOrder::Back,
+            start: true,
+            repeat: Repeat::None,
+        }
+    }
 }
 
 /// A boxed [`Action`].

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -53,14 +53,9 @@ fn setup(mut commands: Commands) {
     // Add multiple actions with custom config
     commands
         .actions(agent)
-        .config(AddConfig {
-            // Add each action to the back of the queue
-            order: AddOrder::Back,
-            // Start the next action if nothing is currently running
-            start: true,
-            // Repeat the action
-            repeat: Repeat::None,
-        })
+        .start(true) // Start the next action if nothing is currently running
+        .order(AddOrder::Back) // Add each action to the back of the queue
+        .repeat(Repeat::None) // Repeat the action
         .add(action_b)
         .add(action_c);
 
@@ -197,8 +192,8 @@ mod plugin;
 mod traits;
 mod world;
 
-// #[cfg(test)]
-// mod tests;
+#[cfg(test)]
+mod tests;
 
 pub use action_commands::*;
 pub use commands::*;

--- a/src/tests.rs
+++ b/src/tests.rs
@@ -518,23 +518,12 @@ fn skip() {
     let e = ecs.spawn_agent();
 
     ecs.actions(e)
-        .config(AddConfig {
-            order: AddOrder::Back,
-            start: false,
-            repeat: Repeat::Amount(0),
-        })
+        .start(false)
+        .repeat(Repeat::Amount(0))
         .add(CountdownAction::new(0))
-        .config(AddConfig {
-            order: AddOrder::Back,
-            start: false,
-            repeat: Repeat::Amount(1),
-        })
+        .repeat(Repeat::Amount(1))
         .add(CountdownAction::new(0))
-        .config(AddConfig {
-            order: AddOrder::Back,
-            start: false,
-            repeat: Repeat::Forever,
-        })
+        .repeat(Repeat::Forever)
         .add(CountdownAction::new(0));
 
     assert!(ecs.action_queue(e).len() == 3);
@@ -570,23 +559,11 @@ fn skip_parallel() {
     let e = ecs.spawn_agent();
 
     ecs.actions(e)
-        .config(AddConfig {
-            order: AddOrder::Back,
-            start: false,
-            repeat: Repeat::None,
-        })
+        .start(false)
         .add_parallel(actions![CountdownAction::new(0), CountdownAction::new(0)])
-        .config(AddConfig {
-            order: AddOrder::Back,
-            start: false,
-            repeat: Repeat::Amount(1),
-        })
+        .repeat(Repeat::Amount(1))
         .add_parallel(actions![CountdownAction::new(0), CountdownAction::new(0)])
-        .config(AddConfig {
-            order: AddOrder::Back,
-            start: false,
-            repeat: Repeat::Forever,
-        })
+        .repeat(Repeat::Forever)
         .add_parallel(actions![CountdownAction::new(0), CountdownAction::new(0)]);
 
     assert!(ecs.action_queue(e).len() == 3);
@@ -622,27 +599,15 @@ fn skip_linked() {
     let e = ecs.spawn_agent();
 
     ecs.actions(e)
-        .config(AddConfig {
-            order: AddOrder::Back,
-            start: false,
-            repeat: Repeat::None,
-        })
+        .start(false)
         .add_linked(|builder| {
             builder.add_sequence(actions![CountdownAction::new(0), CountdownAction::new(0)]);
         })
-        .config(AddConfig {
-            order: AddOrder::Back,
-            start: false,
-            repeat: Repeat::Amount(1),
-        })
+        .repeat(Repeat::Amount(1))
         .add_linked(|builder| {
             builder.add_sequence(actions![CountdownAction::new(0), CountdownAction::new(0)]);
         })
-        .config(AddConfig {
-            order: AddOrder::Back,
-            start: false,
-            repeat: Repeat::Forever,
-        })
+        .repeat(Repeat::Forever)
         .add_linked(|builder| {
             builder.add_sequence(actions![CountdownAction::new(0), CountdownAction::new(0)]);
         });
@@ -704,17 +669,9 @@ fn repeat_amount() {
     let e = ecs.spawn_agent();
 
     ecs.actions(e)
-        .config(AddConfig {
-            order: AddOrder::Back,
-            start: true,
-            repeat: Repeat::Amount(0),
-        })
+        .repeat(Repeat::Amount(0))
         .add(CountdownAction::new(0))
-        .config(AddConfig {
-            order: AddOrder::Back,
-            start: true,
-            repeat: Repeat::Amount(1),
-        })
+        .repeat(Repeat::Amount(1))
         .add(CountdownAction::new(0));
 
     assert!(ecs.current_action(e).is_some());
@@ -741,11 +698,7 @@ fn repeat_forever() {
     let e = ecs.spawn_agent();
 
     ecs.actions(e)
-        .config(AddConfig {
-            order: AddOrder::Back,
-            start: true,
-            repeat: Repeat::Forever,
-        })
+        .repeat(Repeat::Forever)
         .add(CountdownAction::new(0));
 
     assert!(ecs.current_action(e).is_some());
@@ -847,11 +800,9 @@ fn order() {
     // A, B, C
     ecs.actions(e)
         .clear()
-        .config(AddConfig {
-            order: AddOrder::Front,
-            start: false,
-            repeat: Repeat::Amount(0),
-        })
+        .start(false)
+        .order(AddOrder::Front)
+        .repeat(Repeat::Amount(0))
         .add_sequence(actions![
             Order::<A>::default(),
             Order::<B>::default(),
@@ -872,11 +823,9 @@ fn order() {
     // C, B, A
     ecs.actions(e)
         .clear()
-        .config(AddConfig {
-            order: AddOrder::Front,
-            start: false,
-            repeat: Repeat::Amount(0),
-        })
+        .start(false)
+        .order(AddOrder::Front)
+        .repeat(Repeat::Amount(0))
         .add_sequence(actions![
             Order::<C>::default(),
             Order::<B>::default(),
@@ -912,11 +861,7 @@ fn pause_resume() {
 
     ecs.actions(e)
         .pause()
-        .config(AddConfig {
-            order: AddOrder::Front,
-            start: true,
-            repeat: Repeat::None,
-        })
+        .order(AddOrder::Front)
         .add(CountdownAction::new(2));
 
     assert!(countdown_value(&mut ecs.world) == 2);

--- a/src/traits.rs
+++ b/src/traits.rs
@@ -66,6 +66,9 @@ pub trait ActionsProxy<'a> {
 
 /// Methods for modifying actions.
 pub trait ModifyActions {
+    fn start(&mut self, start: bool) -> &mut Self;
+    fn order(&mut self, order: AddOrder) -> &mut Self;
+    fn repeat(&mut self, repeat: Repeat) -> &mut Self;
     /// Sets the current [`config`](AddConfig) for actions to be added.
     fn config(&mut self, config: AddConfig) -> &mut Self;
 

--- a/src/traits.rs
+++ b/src/traits.rs
@@ -69,8 +69,6 @@ pub trait ModifyActions {
     fn start(&mut self, start: bool) -> &mut Self;
     fn order(&mut self, order: AddOrder) -> &mut Self;
     fn repeat(&mut self, repeat: Repeat) -> &mut Self;
-    /// Sets the current [`config`](AddConfig) for actions to be added.
-    fn config(&mut self, config: AddConfig) -> &mut Self;
 
     /// Adds a single [`action`](Action) to the queue.
     fn add(&mut self, action: impl IntoBoxedAction) -> &mut Self;

--- a/src/traits.rs
+++ b/src/traits.rs
@@ -66,8 +66,17 @@ pub trait ActionsProxy<'a> {
 
 /// Methods for modifying actions.
 pub trait ModifyActions {
+    /// Specify if the next [`action`](Action) in the queue should [`start`](Action::on_start) when added.
+    /// It will only start if nothing is currently running.
+    /// Default is `true`.
     fn start(&mut self, start: bool) -> &mut Self;
+
+    /// Specify the queue order for actions to be added.
+    /// Default is [`AddOrder::Back`].
     fn order(&mut self, order: AddOrder) -> &mut Self;
+
+    /// Specify the repeat configuration for actions to be added.
+    /// Default is [`Repeat::None`].
     fn repeat(&mut self, repeat: Repeat) -> &mut Self;
 
     /// Adds a single [`action`](Action) to the queue.

--- a/src/world.rs
+++ b/src/world.rs
@@ -6,7 +6,7 @@ impl<'a> ActionsProxy<'a> for World {
     fn actions(&'a mut self, agent: Entity) -> AgentWorldActions<'a> {
         AgentWorldActions {
             agent,
-            config: AddConfig::default(),
+            config: AddConfig::new(),
             world: self,
         }
     }

--- a/src/world.rs
+++ b/src/world.rs
@@ -20,6 +20,21 @@ pub struct AgentWorldActions<'w> {
 }
 
 impl ModifyActions for AgentWorldActions<'_> {
+    fn start(&mut self, start: bool) -> &mut Self {
+        self.config.start = start;
+        self
+    }
+
+    fn order(&mut self, order: AddOrder) -> &mut Self {
+        self.config.order = order;
+        self
+    }
+
+    fn repeat(&mut self, repeat: Repeat) -> &mut Self {
+        self.config.repeat = repeat;
+        self
+    }
+
     fn config(&mut self, config: AddConfig) -> &mut Self {
         self.config = config;
         self

--- a/src/world.rs
+++ b/src/world.rs
@@ -35,11 +35,6 @@ impl ModifyActions for AgentWorldActions<'_> {
         self
     }
 
-    fn config(&mut self, config: AddConfig) -> &mut Self {
-        self.config = config;
-        self
-    }
-
     fn add(&mut self, action: impl IntoBoxedAction) -> &mut Self {
         self.world.add_action(self.agent, self.config, action);
         self


### PR DESCRIPTION
This PR makes the `AddConfig` struct private, and replaces the `config` method with three new methods: `start`, `order` and `repeat`.

```rust
// old
commands
    .actions(agent)
    .config(AddConfig {
        start: true,
        order: AddOrder::Back,
        repeat: Repeat::None,
    });

// new
commands
    .actions(agent)
    .start(true)
    .order(AddOrder::Back)
    .repeat(Repeat::None);
```