### PR TITLE
Add `execute` method to `ModifyActions` trait

### DIFF
--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -6,6 +6,7 @@
 - [Replace `config` with `start`, `order` and `repeat` methods][64]
 - [Replace `IntoBoxedAction` trait with `From<Box<dyn Action>>`][65]
 - [Don't advance the action queue when canceling][67]
+- [Add `execute` method to `ModifyActions` trait][68]
 
 ## Version 0.6.0
 
@@ -45,6 +46,7 @@
 
 First release! 🎉
 
+[68]: https://github.com/hikikones/bevy-sequential-actions/pull/68
 [67]: https://github.com/hikikones/bevy-sequential-actions/pull/67
 [65]: https://github.com/hikikones/bevy-sequential-actions/pull/65
 [64]: https://github.com/hikikones/bevy-sequential-actions/pull/64

--- a/examples/pause.rs
+++ b/examples/pause.rs
@@ -50,7 +50,7 @@ fn input(
     if keyboard.just_pressed(KeyCode::Space) {
         for agent in agents_q.iter() {
             if *is_paused {
-                commands.actions(agent).next();
+                commands.actions(agent).execute();
             } else {
                 commands.actions(agent).pause();
             }

--- a/src/action_commands.rs
+++ b/src/action_commands.rs
@@ -112,6 +112,16 @@ impl ModifyActions for AgentActions<'_> {
         self
     }
 
+    fn execute(&mut self) -> &mut Self {
+        let agent = self.agent;
+
+        self.commands.add(move |world: &mut World| {
+            world.execute_actions(agent);
+        });
+
+        self
+    }
+
     fn next(&mut self) -> &mut Self {
         let agent = self.agent;
 

--- a/src/commands.rs
+++ b/src/commands.rs
@@ -89,6 +89,16 @@ impl ModifyActions for AgentCommandsActions<'_, '_, '_> {
         self
     }
 
+    fn execute(&mut self) -> &mut Self {
+        let agent = self.agent;
+
+        self.commands.add(move |world: &mut World| {
+            world.execute_actions(agent);
+        });
+
+        self
+    }
+
     fn next(&mut self) -> &mut Self {
         let agent = self.agent;
 

--- a/src/traits.rs
+++ b/src/traits.rs
@@ -90,6 +90,10 @@ pub trait ModifyActions {
         f: impl FnOnce(&mut LinkedActionsBuilder) + Send + Sync + 'static,
     ) -> &mut Self;
 
+    /// [`Starts`](Action::on_start) the next [`action`](Action) in the queue,
+    /// but only if there are no actions currently running.
+    fn execute(&mut self) -> &mut Self;
+
     /// [`Starts`](Action::on_start) the next [`action`](Action) in the queue.
     /// Current action is [`stopped`](Action::on_stop) as [`canceled`](StopReason::Canceled).
     fn next(&mut self) -> &mut Self;

--- a/src/traits.rs
+++ b/src/traits.rs
@@ -91,7 +91,7 @@ pub trait ModifyActions {
     ) -> &mut Self;
 
     /// [`Starts`](Action::on_start) the next [`action`](Action) in the queue,
-    /// but only if there are no actions currently running.
+    /// but only if there is no action currently running.
     fn execute(&mut self) -> &mut Self;
 
     /// [`Starts`](Action::on_start) the next [`action`](Action) in the queue.

--- a/src/world.rs
+++ b/src/world.rs
@@ -66,6 +66,11 @@ impl ModifyActions for AgentWorldActions<'_> {
         self
     }
 
+    fn execute(&mut self) -> &mut Self {
+        self.world.execute_actions(self.agent);
+        self
+    }
+
     fn next(&mut self) -> &mut Self {
         self.world.next_action(self.agent);
         self
@@ -112,6 +117,7 @@ pub(super) trait ModifyActionsWorldExt {
         config: AddConfig,
         actions: impl FnOnce(&mut LinkedActionsBuilder),
     );
+    fn execute_actions(&mut self, agent: Entity);
     fn next_action(&mut self, agent: Entity);
     fn finish_action(&mut self, agent: Entity);
     fn cancel_action(&mut self, agent: Entity);
@@ -193,6 +199,12 @@ impl ModifyActionsWorldExt for World {
         }
 
         if config.start && !self.has_current_action(agent) {
+            self.start_next_action(agent);
+        }
+    }
+
+    fn execute_actions(&mut self, agent: Entity) {
+        if !self.has_current_action(agent) {
             self.start_next_action(agent);
         }
     }


### PR DESCRIPTION
The `execute` method allows for manually starting the action queue. It will only start the next action in the queue if no action is currently running. Currently you have to call `next` for this behavior, but `next` also cancels the current action, which is not always desired.