### PR TITLE
Add `ModifyActionsExt` trait for `EntityCommands` and `EntityWorldMut`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,12 @@
 # Changelog
 
+## Version 0.12.0-dev
+
+- [Add `ModifyActionsExt` trait for `EntityCommands` and `EntityWorldMut`][98]
+    - Deprecates `ModifyActions` trait
+
+[98]: https://github.com/hikikones/bevy-sequential-actions/pull/98
+
 ## Version 0.11.0
 
 - [Update to Bevy 0.14][97]

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,10 +2,10 @@
 
 ## Version 0.12.0-dev
 
-- [Add `ModifyActionsExt` trait for `EntityCommands` and `EntityWorldMut`][98]
+- [Add `ModifyActionsExt` trait for `EntityCommands` and `EntityWorldMut`][99]
     - Deprecates `ModifyActions` trait
 
-[98]: https://github.com/hikikones/bevy-sequential-actions/pull/98
+[99]: https://github.com/hikikones/bevy-sequential-actions/pull/99
 
 ## Version 0.11.0
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "bevy-sequential-actions"
-version = "0.11.0"
+version = "0.12.0-dev"
 edition = "2021"
 license = "MIT OR Apache-2.0"
 authors = ["hikikones"]

--- a/README.md
+++ b/README.md
@@ -56,9 +56,6 @@ pub struct WaitAction {
     current: Option<f32>, // None
 }
 
-#[derive(Component)]
-struct WaitTimer(f32);
-
 impl Action for WaitAction {
     fn is_finished(&self, agent: Entity, world: &World) -> bool {
         // Determine if wait timer has reached zero.
@@ -88,6 +85,9 @@ impl Action for WaitAction {
         }
     }
 }
+
+#[derive(Component)]
+struct WaitTimer(f32);
 
 fn wait_system(mut wait_timer_q: Query<&mut WaitTimer>, time: Res<Time>) {
     for mut wait_timer in &mut wait_timer_q {

--- a/README.md
+++ b/README.md
@@ -128,8 +128,7 @@ fn setup(mut commands: Commands) {
             AddConfig::default(),
             |_agent, world: &mut World| -> bool {
                 // on_start
-                world.send_event(AppExit::Success);
-                false
+                true
             },
         );
 }

--- a/README.md
+++ b/README.md
@@ -108,29 +108,24 @@ fn setup(mut commands: Commands) {
         // Spawn entity with the bundle
         .spawn(ActionsBundle::new())
         // Add a single action
-        .add_action(
+        .add_action(action_a)
+        // Add multiple actions with a specified config
+        .add_actions_with_config(
             AddConfig {
                 start: true, // Start next action if nothing is currently running
                 order: AddOrder::Back, // Add the action to the back of the queue
             },
-            action_a,
-        )
-        // Add multiple actions
-        .add_actions(
-            AddConfig::default(),
+            // Helper macro for creating an array of boxed actions
             actions![
                 action_b,
                 action_c
             ],
         )
         // Add an anonymous action with a closure
-        .add_action(
-            AddConfig::default(),
-            |_agent, world: &mut World| -> bool {
-                // on_start
-                true
-            },
-        );
+        .add_action(|_agent, world: &mut World| -> bool {
+            // on_start
+            true
+        });
 }
 ```
 

--- a/benches/benches.rs
+++ b/benches/benches.rs
@@ -33,7 +33,7 @@ fn run_many_countdowns(agents: u32) {
 
     for i in 0..agents {
         let agent = app.world_mut().spawn(ActionsBundle::new()).id();
-        app.world_mut().entity_mut(agent).add_action(
+        app.world_mut().entity_mut(agent).add_action_with_config(
             AddConfig::default(),
             CountdownAction {
                 count: i,

--- a/benches/benches.rs
+++ b/benches/benches.rs
@@ -33,10 +33,13 @@ fn run_many_countdowns(agents: u32) {
 
     for i in 0..agents {
         let agent = app.world_mut().spawn(ActionsBundle::new()).id();
-        app.world_mut().actions(agent).add(CountdownAction {
-            count: i,
-            current: None,
-        });
+        app.world_mut().entity_mut(agent).add_action(
+            AddConfig::default(),
+            CountdownAction {
+                count: i,
+                current: None,
+            },
+        );
     }
 
     for _ in 0..10 {

--- a/examples/basic.rs
+++ b/examples/basic.rs
@@ -12,19 +12,27 @@ fn main() {
 }
 
 fn setup(mut commands: Commands) {
-    let agent = commands.spawn(ActionsBundle::new()).id();
     commands
-        .actions(agent)
+        .spawn(ActionsBundle::new())
         // Add a single action
-        .add(DemoAction)
+        .add_action(
+            AddConfig {
+                start: true,
+                order: AddOrder::Back,
+            },
+            DemoAction,
+        )
         // Add multiple actions
-        .add_many(actions![
-            PrintAction("hello"),
-            PrintAction("there"),
-            CountdownAction::new(10)
-        ])
+        .add_actions(
+            AddConfig::default(),
+            actions![
+                PrintAction("hello"),
+                PrintAction("there"),
+                CountdownAction::new(10)
+            ],
+        )
         // Add an anonymous action with a closure
-        .add(|_agent, world: &mut World| -> bool {
+        .add_action(AddConfig::default(), |_agent, world: &mut World| -> bool {
             // on_start
             world.send_event(AppExit::Success);
             false

--- a/examples/basic.rs
+++ b/examples/basic.rs
@@ -13,12 +13,13 @@ fn main() {
 
 fn setup(mut commands: Commands) {
     commands
+        // Spawn entity with the bundle
         .spawn(ActionsBundle::new())
         // Add a single action
         .add_action(
             AddConfig {
-                start: true,
-                order: AddOrder::Back,
+                start: true,           // Start next action in the queue if nothing is currently running
+                order: AddOrder::Back, // Add the action to the back of the queue
             },
             DemoAction,
         )

--- a/examples/basic.rs
+++ b/examples/basic.rs
@@ -16,16 +16,14 @@ fn setup(mut commands: Commands) {
         // Spawn entity with the bundle
         .spawn(ActionsBundle::new())
         // Add a single action
-        .add_action(
+        .add_action(DemoAction)
+        // Add multiple actions with a specified config
+        .add_actions_with_config(
             AddConfig {
                 start: true,           // Start next action in the queue if nothing is currently running
                 order: AddOrder::Back, // Add the action to the back of the queue
             },
-            DemoAction,
-        )
-        // Add multiple actions
-        .add_actions(
-            AddConfig::default(),
+            // Helper macro for creating an array of boxed actions
             actions![
                 PrintAction("hello"),
                 PrintAction("there"),
@@ -33,7 +31,7 @@ fn setup(mut commands: Commands) {
             ],
         )
         // Add an anonymous action with a closure
-        .add_action(AddConfig::default(), |_agent, world: &mut World| -> bool {
+        .add_action(|_agent, world: &mut World| -> bool {
             // on_start
             world.send_event(AppExit::Success);
             false

--- a/examples/custom.rs
+++ b/examples/custom.rs
@@ -21,7 +21,7 @@ fn setup(mut commands: Commands) {
         // Spawn agents with id in ascending order
         commands
             .spawn((ActionsBundle::new(), Id(i)))
-            .add_action(AddConfig::default(), PrintIdAction);
+            .add_action(PrintIdAction);
     }
 }
 

--- a/examples/custom.rs
+++ b/examples/custom.rs
@@ -19,8 +19,9 @@ fn main() {
 fn setup(mut commands: Commands) {
     for i in 0..10 {
         // Spawn agents with id in ascending order
-        let agent = commands.spawn((ActionsBundle::new(), Id(i))).id();
-        commands.actions(agent).add(PrintIdAction);
+        commands
+            .spawn((ActionsBundle::new(), Id(i)))
+            .add_action(AddConfig::default(), PrintIdAction);
     }
 }
 

--- a/examples/despawn.rs
+++ b/examples/despawn.rs
@@ -12,14 +12,11 @@ fn main() {
 }
 
 fn setup(mut commands: Commands) {
-    commands.spawn(ActionsBundle::new()).add_actions(
-        AddConfig::default(),
-        actions![
-            PrintAction("First action"),
-            DespawnAction,
-            EmptyAction, // This action does not start, but on_remove and on_drop are called
-        ],
-    );
+    commands.spawn(ActionsBundle::new()).add_actions(actions![
+        PrintAction("First action"),
+        DespawnAction,
+        EmptyAction, // This action does not start, but on_remove and on_drop are called
+    ]);
 }
 
 struct DespawnAction;

--- a/examples/despawn.rs
+++ b/examples/despawn.rs
@@ -12,12 +12,14 @@ fn main() {
 }
 
 fn setup(mut commands: Commands) {
-    let agent = commands.spawn(ActionsBundle::new()).id();
-    commands.actions(agent).add_many(actions![
-        PrintAction("First action"),
-        DespawnAction,
-        EmptyAction, // This action does not start, but on_remove and on_drop is called
-    ]);
+    commands.spawn(ActionsBundle::new()).add_actions(
+        AddConfig::default(),
+        actions![
+            PrintAction("First action"),
+            DespawnAction,
+            EmptyAction, // This action does not start, but on_remove and on_drop is called
+        ],
+    );
 }
 
 struct DespawnAction;
@@ -31,7 +33,7 @@ impl Action for DespawnAction {
     fn on_start(&mut self, agent: Entity, world: &mut World) -> bool {
         println!("Despawn!");
 
-        world.actions(agent).clear();
+        world.entity_mut(agent).clear_actions();
         world.despawn(agent);
 
         // Don't advance the action queue

--- a/examples/despawn.rs
+++ b/examples/despawn.rs
@@ -17,7 +17,7 @@ fn setup(mut commands: Commands) {
         actions![
             PrintAction("First action"),
             DespawnAction,
-            EmptyAction, // This action does not start, but on_remove and on_drop is called
+            EmptyAction, // This action does not start, but on_remove and on_drop are called
         ],
     );
 }

--- a/examples/parallel.rs
+++ b/examples/parallel.rs
@@ -12,21 +12,23 @@ fn main() {
 }
 
 fn setup(mut commands: Commands) {
-    let agent = commands.spawn(ActionsBundle::new()).id();
-    commands
-        .actions(agent)
-        .add(ParallelActions {
-            actions: actions![
-                PrintAction("hello"),
-                CountdownAction::new(2),
-                PrintAction("world"),
-                CountdownAction::new(4),
-            ],
-        })
-        .add(|_agent, world: &mut World| {
-            world.send_event(AppExit::Success);
-            false
-        });
+    commands.spawn(ActionsBundle::new()).add_actions(
+        AddConfig::default(),
+        actions![
+            ParallelActions {
+                actions: actions![
+                    PrintAction("hello"),
+                    CountdownAction::new(2),
+                    PrintAction("world"),
+                    CountdownAction::new(4),
+                ],
+            },
+            |_agent, world: &mut World| {
+                world.send_event(AppExit::Success);
+                false
+            }
+        ],
+    );
 }
 
 struct ParallelActions<const N: usize> {

--- a/examples/parallel.rs
+++ b/examples/parallel.rs
@@ -12,23 +12,20 @@ fn main() {
 }
 
 fn setup(mut commands: Commands) {
-    commands.spawn(ActionsBundle::new()).add_actions(
-        AddConfig::default(),
-        actions![
-            ParallelActions {
-                actions: actions![
-                    PrintAction("hello"),
-                    CountdownAction::new(2),
-                    PrintAction("world"),
-                    CountdownAction::new(4),
-                ],
-            },
-            |_agent, world: &mut World| {
-                world.send_event(AppExit::Success);
-                false
-            }
-        ],
-    );
+    commands.spawn(ActionsBundle::new()).add_actions(actions![
+        ParallelActions {
+            actions: actions![
+                PrintAction("hello"),
+                CountdownAction::new(2),
+                PrintAction("world"),
+                CountdownAction::new(4),
+            ],
+        },
+        |_agent, world: &mut World| {
+            world.send_event(AppExit::Success);
+            false
+        }
+    ]);
 }
 
 struct ParallelActions<const N: usize> {

--- a/examples/pause.rs
+++ b/examples/pause.rs
@@ -36,7 +36,7 @@ fn frame_logic(
 
     if *frame == PAUSE_FRAME {
         println!("\nPAUSE\n");
-        commands.entity(agent_q.single()).pause_current_action();
+        commands.entity(agent_q.single()).pause_action();
     }
     if *frame == RESUME_FRAME {
         println!("\nRESUME\n");

--- a/examples/pause.rs
+++ b/examples/pause.rs
@@ -19,7 +19,7 @@ fn main() {
 fn setup(mut commands: Commands) {
     commands
         .spawn(ActionsBundle::new())
-        .add_action(AddConfig::default(), CountForeverAction);
+        .add_action(CountForeverAction);
 }
 
 fn frame_logic(

--- a/examples/pause.rs
+++ b/examples/pause.rs
@@ -17,8 +17,9 @@ fn main() {
 }
 
 fn setup(mut commands: Commands) {
-    let agent = commands.spawn(ActionsBundle::new()).id();
-    commands.actions(agent).add(CountForeverAction);
+    commands
+        .spawn(ActionsBundle::new())
+        .add_action(AddConfig::default(), CountForeverAction);
 }
 
 fn frame_logic(
@@ -35,11 +36,11 @@ fn frame_logic(
 
     if *frame == PAUSE_FRAME {
         println!("\nPAUSE\n");
-        commands.actions(agent_q.single()).pause();
+        commands.entity(agent_q.single()).pause_current_action();
     }
     if *frame == RESUME_FRAME {
         println!("\nRESUME\n");
-        commands.actions(agent_q.single()).execute();
+        commands.entity(agent_q.single()).execute_actions();
     }
     if *frame == EXIT_FRAME {
         println!(

--- a/examples/repeat.rs
+++ b/examples/repeat.rs
@@ -11,27 +11,29 @@ fn main() {
 }
 
 fn setup(mut commands: Commands) {
-    let agent = commands.spawn(ActionsBundle::new()).id();
-    commands.actions(agent).add_many(actions![
-        RepeatAction {
-            action: PrintAction("hello"),
-            repeat: 3,
-        },
-        RepeatAction {
-            action: PrintAction("world"),
-            repeat: 1,
-        },
-        RepeatAction {
-            action: |agent, world: &mut World| {
-                // Exit app when action queue is empty
-                if world.get::<ActionQueue>(agent).unwrap().is_empty() {
-                    world.send_event(AppExit::Success);
-                }
-                false
+    commands.spawn(ActionsBundle::new()).add_actions(
+        AddConfig::default(),
+        actions![
+            RepeatAction {
+                action: PrintAction("hello"),
+                repeat: 3,
             },
-            repeat: u32::MAX,
-        },
-    ]);
+            RepeatAction {
+                action: PrintAction("world"),
+                repeat: 1,
+            },
+            RepeatAction {
+                action: |agent, world: &mut World| {
+                    // Exit app when action queue is empty
+                    if world.get::<ActionQueue>(agent).unwrap().is_empty() {
+                        world.send_event(AppExit::Success);
+                    }
+                    false
+                },
+                repeat: u32::MAX,
+            },
+        ],
+    );
 }
 
 struct RepeatAction<A: Action> {

--- a/examples/repeat.rs
+++ b/examples/repeat.rs
@@ -11,29 +11,26 @@ fn main() {
 }
 
 fn setup(mut commands: Commands) {
-    commands.spawn(ActionsBundle::new()).add_actions(
-        AddConfig::default(),
-        actions![
-            RepeatAction {
-                action: PrintAction("hello"),
-                repeat: 3,
+    commands.spawn(ActionsBundle::new()).add_actions(actions![
+        RepeatAction {
+            action: PrintAction("hello"),
+            repeat: 3,
+        },
+        RepeatAction {
+            action: PrintAction("world"),
+            repeat: 1,
+        },
+        RepeatAction {
+            action: |agent, world: &mut World| {
+                // Exit app when action queue is empty
+                if world.get::<ActionQueue>(agent).unwrap().is_empty() {
+                    world.send_event(AppExit::Success);
+                }
+                false
             },
-            RepeatAction {
-                action: PrintAction("world"),
-                repeat: 1,
-            },
-            RepeatAction {
-                action: |agent, world: &mut World| {
-                    // Exit app when action queue is empty
-                    if world.get::<ActionQueue>(agent).unwrap().is_empty() {
-                        world.send_event(AppExit::Success);
-                    }
-                    false
-                },
-                repeat: u32::MAX,
-            },
-        ],
-    );
+            repeat: u32::MAX,
+        },
+    ]);
 }
 
 struct RepeatAction<A: Action> {

--- a/examples/schedule.rs
+++ b/examples/schedule.rs
@@ -54,15 +54,21 @@ fn run_custom_schedule(world: &mut World, mut frame_count: Local<u32>) {
 fn setup(mut commands: Commands) {
     // Spawn agent with even marker for even schedule
     let agent_even = commands.spawn((ActionsBundle::new(), EvenMarker)).id();
-    commands.actions(agent_even).add(PrintForeverAction(format!(
-        "Even: is_finished is called every even frame for agent {agent_even:?}."
-    )));
+    commands.entity(agent_even).add_action(
+        AddConfig::default(),
+        PrintForeverAction(format!(
+            "Even: is_finished is called every even frame for agent {agent_even:?}."
+        )),
+    );
 
     // Spawn agent with odd marker for odd schedule
     let agent_odd = commands.spawn((ActionsBundle::new(), OddMarker)).id();
-    commands.actions(agent_odd).add(PrintForeverAction(format!(
-        "Odd:  is_finished is called every odd  frame for agent {agent_odd:?}."
-    )));
+    commands.entity(agent_odd).add_action(
+        AddConfig::default(),
+        PrintForeverAction(format!(
+            "Odd:  is_finished is called every odd  frame for agent {agent_odd:?}."
+        )),
+    );
 }
 
 struct PrintForeverAction(String);

--- a/examples/schedule.rs
+++ b/examples/schedule.rs
@@ -54,21 +54,19 @@ fn run_custom_schedule(world: &mut World, mut frame_count: Local<u32>) {
 fn setup(mut commands: Commands) {
     // Spawn agent with even marker for even schedule
     let agent_even = commands.spawn((ActionsBundle::new(), EvenMarker)).id();
-    commands.entity(agent_even).add_action(
-        AddConfig::default(),
-        PrintForeverAction(format!(
+    commands
+        .entity(agent_even)
+        .add_action(PrintForeverAction(format!(
             "Even: is_finished is called every even frame for agent {agent_even:?}."
-        )),
-    );
+        )));
 
     // Spawn agent with odd marker for odd schedule
     let agent_odd = commands.spawn((ActionsBundle::new(), OddMarker)).id();
-    commands.entity(agent_odd).add_action(
-        AddConfig::default(),
-        PrintForeverAction(format!(
+    commands
+        .entity(agent_odd)
+        .add_action(PrintForeverAction(format!(
             "Odd:  is_finished is called every odd  frame for agent {agent_odd:?}."
-        )),
-    );
+        )));
 }
 
 struct PrintForeverAction(String);

--- a/examples/sequence.rs
+++ b/examples/sequence.rs
@@ -11,18 +11,20 @@ fn main() {
 }
 
 fn setup(mut commands: Commands) {
-    let agent = commands.spawn(ActionsBundle::new()).id();
-    commands.actions(agent).add(ActionSequence::new(actions![
-        PrintAction("see"),
-        PrintAction("you"),
-        PrintAction("in"),
-        PrintAction("space"),
-        PrintAction("cowboy"),
-        |_agent, world: &mut World| -> bool {
-            world.send_event(AppExit::Success);
-            false
-        }
-    ]));
+    commands.spawn(ActionsBundle::new()).add_action(
+        AddConfig::default(),
+        ActionSequence::new(actions![
+            PrintAction("see"),
+            PrintAction("you"),
+            PrintAction("in"),
+            PrintAction("space"),
+            PrintAction("cowboy"),
+            |_agent, world: &mut World| -> bool {
+                world.send_event(AppExit::Success);
+                false
+            }
+        ]),
+    );
 }
 
 struct ActionSequence<const N: usize> {

--- a/examples/sequence.rs
+++ b/examples/sequence.rs
@@ -11,9 +11,9 @@ fn main() {
 }
 
 fn setup(mut commands: Commands) {
-    commands.spawn(ActionsBundle::new()).add_action(
-        AddConfig::default(),
-        ActionSequence::new(actions![
+    commands
+        .spawn(ActionsBundle::new())
+        .add_action(ActionSequence::new(actions![
             PrintAction("see"),
             PrintAction("you"),
             PrintAction("in"),
@@ -23,8 +23,7 @@ fn setup(mut commands: Commands) {
                 world.send_event(AppExit::Success);
                 false
             }
-        ]),
-    );
+        ]));
 }
 
 struct ActionSequence<const N: usize> {

--- a/src/commands.rs
+++ b/src/commands.rs
@@ -99,7 +99,10 @@ impl<'c, 'w: 'c, 's: 'c> ActionsProxy<'c> for Commands<'w, 's> {
     }
 }
 
-#[deprecated]
+#[deprecated(
+    since = "0.12.0",
+    note = "Replaced by ModifyActionsExt trait implemented for EntityCommands and EntityWorldMut."
+)]
 /// Modify actions using [`Commands`].
 pub struct AgentCommands<'c, 'w, 's> {
     agent: Entity,

--- a/src/commands.rs
+++ b/src/commands.rs
@@ -46,7 +46,7 @@ impl ModifyActionsExt for EntityCommands<'_> {
         self
     }
 
-    fn cancel_current_action(&mut self) -> &mut Self {
+    fn cancel_action(&mut self) -> &mut Self {
         let agent = self.id();
 
         self.commands().add(move |world: &mut World| {
@@ -56,7 +56,7 @@ impl ModifyActionsExt for EntityCommands<'_> {
         self
     }
 
-    fn pause_current_action(&mut self) -> &mut Self {
+    fn pause_action(&mut self) -> &mut Self {
         let agent = self.id();
 
         self.commands().add(move |world: &mut World| {

--- a/src/commands.rs
+++ b/src/commands.rs
@@ -1,5 +1,92 @@
 use crate::*;
 
+impl ModifyActionsExt for EntityCommands<'_> {
+    fn add_action(&mut self, config: AddConfig, action: impl Action) -> &mut Self {
+        let agent = self.id();
+
+        self.commands().add(move |world: &mut World| {
+            SequentialActionsPlugin::add_action(agent, config, action, world);
+        });
+
+        self
+    }
+
+    fn add_actions<I>(&mut self, config: AddConfig, actions: I) -> &mut Self
+    where
+        I: IntoIterator<Item = BoxedAction> + Send + 'static,
+        I::IntoIter: DoubleEndedIterator,
+    {
+        let agent = self.id();
+
+        self.commands().add(move |world: &mut World| {
+            SequentialActionsPlugin::add_actions(agent, config, actions, world);
+        });
+
+        self
+    }
+
+    fn execute_actions(&mut self) -> &mut Self {
+        let agent = self.id();
+
+        self.commands().add(move |world: &mut World| {
+            SequentialActionsPlugin::execute_actions(agent, world);
+        });
+
+        self
+    }
+
+    fn next_action(&mut self) -> &mut Self {
+        let agent = self.id();
+
+        self.commands().add(move |world: &mut World| {
+            SequentialActionsPlugin::stop_current_action(agent, StopReason::Canceled, world);
+            SequentialActionsPlugin::start_next_action(agent, world);
+        });
+
+        self
+    }
+
+    fn cancel_current_action(&mut self) -> &mut Self {
+        let agent = self.id();
+
+        self.commands().add(move |world: &mut World| {
+            SequentialActionsPlugin::stop_current_action(agent, StopReason::Canceled, world);
+        });
+
+        self
+    }
+
+    fn pause_current_action(&mut self) -> &mut Self {
+        let agent = self.id();
+
+        self.commands().add(move |world: &mut World| {
+            SequentialActionsPlugin::stop_current_action(agent, StopReason::Paused, world);
+        });
+
+        self
+    }
+
+    fn skip_next_action(&mut self) -> &mut Self {
+        let agent = self.id();
+
+        self.commands().add(move |world: &mut World| {
+            SequentialActionsPlugin::skip_next_action(agent, world);
+        });
+
+        self
+    }
+
+    fn clear_actions(&mut self) -> &mut Self {
+        let agent = self.id();
+
+        self.commands().add(move |world: &mut World| {
+            SequentialActionsPlugin::clear_actions(agent, world);
+        });
+
+        self
+    }
+}
+
 impl<'c, 'w: 'c, 's: 'c> ActionsProxy<'c> for Commands<'w, 's> {
     type Modifier = AgentCommands<'c, 'w, 's>;
 
@@ -12,6 +99,7 @@ impl<'c, 'w: 'c, 's: 'c> ActionsProxy<'c> for Commands<'w, 's> {
     }
 }
 
+#[deprecated]
 /// Modify actions using [`Commands`].
 pub struct AgentCommands<'c, 'w, 's> {
     agent: Entity,

--- a/src/commands.rs
+++ b/src/commands.rs
@@ -1,7 +1,7 @@
 use crate::*;
 
 impl ModifyActionsExt for EntityCommands<'_> {
-    fn add_action(&mut self, config: AddConfig, action: impl Action) -> &mut Self {
+    fn add_action_with_config(&mut self, config: AddConfig, action: impl Action) -> &mut Self {
         let agent = self.id();
 
         self.commands().add(move |world: &mut World| {
@@ -11,7 +11,7 @@ impl ModifyActionsExt for EntityCommands<'_> {
         self
     }
 
-    fn add_actions<I>(&mut self, config: AddConfig, actions: I) -> &mut Self
+    fn add_actions_with_config<I>(&mut self, config: AddConfig, actions: I) -> &mut Self
     where
         I: IntoIterator<Item = BoxedAction> + Send + 'static,
         I::IntoIter: DoubleEndedIterator,

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -134,29 +134,24 @@ fn setup(mut commands: Commands) {
         // Spawn entity with the bundle
         .spawn(ActionsBundle::new())
         // Add a single action
-        .add_action(
+        .add_action(action_a)
+        // Add multiple actions with a specified config
+        .add_actions_with_config(
             AddConfig {
                 start: true, // Start next action if nothing is currently running
                 order: AddOrder::Back, // Add the action to the back of the queue
             },
-            action_a,
-        )
-        // Add multiple actions
-        .add_actions(
-            AddConfig::default(),
+            // Helper macro for creating an array of boxed actions
             actions![
                 action_b,
                 action_c
             ],
         )
         // Add an anonymous action with a closure
-        .add_action(
-            AddConfig::default(),
-            |_agent, world: &mut World| -> bool {
-                // on_start
-                true
-            },
-        );
+        .add_action(|_agent, world: &mut World| -> bool {
+            // on_start
+            true
+        });
 }
 ```
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -68,9 +68,6 @@ pub struct WaitAction {
     current: Option<f32>, // None
 }
 
-#[derive(Component)]
-struct WaitTimer(f32);
-
 impl Action for WaitAction {
     fn is_finished(&self, agent: Entity, world: &World) -> bool {
         // Determine if wait timer has reached zero.
@@ -100,6 +97,9 @@ impl Action for WaitAction {
         }
     }
 }
+
+#[derive(Component)]
+struct WaitTimer(f32);
 
 fn wait_system(mut wait_timer_q: Query<&mut WaitTimer>, time: Res<Time>) {
     for mut wait_timer in &mut wait_timer_q {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -160,7 +160,7 @@ use std::collections::VecDeque;
 
 use bevy_app::prelude::*;
 use bevy_derive::{Deref, DerefMut};
-use bevy_ecs::prelude::*;
+use bevy_ecs::{prelude::*, system::EntityCommands};
 
 mod commands;
 mod macros;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -25,56 +25,21 @@ The quickest way for getting started is adding the [`SequentialActionsPlugin`] t
 # use bevy_ecs::prelude::*;
 # use bevy_app::prelude::*;
 use bevy_sequential_actions::*;
+#
+# struct DefaultPlugins;
+# impl Plugin for DefaultPlugins { fn build(&self, _app: &mut App) {} }
 
 fn main() {
     App::new()
-        .add_plugins(SequentialActionsPlugin)
+        .add_plugins((DefaultPlugins, SequentialActionsPlugin))
         .run();
-}
-```
-
-#### Modifying Actions
-
-An action is anything that implements the [`Action`] trait,
-and can be added to any [`Entity`] that contains the [`ActionsBundle`].
-An entity with actions is referred to as an `agent`.
-See the [`ModifyActions`] trait for available methods.
-
-```rust,no_run
-# use bevy_ecs::prelude::*;
-# use bevy_sequential_actions::*;
-#
-# struct EmptyAction;
-# impl Action for EmptyAction {
-#   fn is_finished(&self, _a: Entity, _w: &World) -> bool { true.into() }
-#   fn on_start(&mut self, _a: Entity, _w: &mut World) -> bool { true.into() }
-#   fn on_stop(&mut self, _a: Entity, _w: &mut World, _r: StopReason) {}
-# }
-#
-fn setup(mut commands: Commands) {
-#   let action_a = EmptyAction;
-#   let action_b = EmptyAction;
-#   let action_c = EmptyAction;
-#   let action_d = EmptyAction;
-#
-    let agent = commands.spawn(ActionsBundle::new()).id();
-    commands
-        .actions(agent)
-        .add(action_a)
-        .add_many(actions![
-            action_b,
-            action_c
-        ])
-        .order(AddOrder::Front)
-        .add(action_d)
-        // ...
-#       ;
 }
 ```
 
 #### Implementing an Action
 
-The [`Action`] trait contains 3 required methods:
+An action is anything that implements the [`Action`] trait.
+The trait contains 3 required methods:
 
 * [`is_finished`](Action::is_finished) to determine if an action is finished or not.
 * [`on_start`](Action::on_start) which is called when an action is started.
@@ -85,6 +50,8 @@ In addition, there are 3 optional methods:
 * [`on_add`](Action::on_add) which is called when an action is added to the queue.
 * [`on_remove`](Action::on_remove) which is called when an action is removed from the queue.
 * [`on_drop`](Action::on_drop) which is the last method to be called with full ownership.
+
+An entity with actions is referred to as an `agent`.
 
 A simple wait action follows.
 
@@ -100,6 +67,9 @@ pub struct WaitAction {
     duration: f32, // Seconds
     current: Option<f32>, // None
 }
+
+#[derive(Component)]
+struct WaitTimer(f32);
 
 impl Action for WaitAction {
     fn is_finished(&self, agent: Entity, world: &World) -> bool {
@@ -131,13 +101,62 @@ impl Action for WaitAction {
     }
 }
 
-#[derive(Component)]
-struct WaitTimer(f32);
-
 fn wait_system(mut wait_timer_q: Query<&mut WaitTimer>, time: Res<Time>) {
     for mut wait_timer in &mut wait_timer_q {
         wait_timer.0 -= time.delta_seconds();
     }
+}
+```
+
+#### Modifying Actions
+
+Actions can be added to any [`Entity`] that contains the [`ActionsBundle`].
+See the [`ModifyActionsExt`] trait for available methods.
+The extension trait is implemented for both [`EntityCommands`] and [`EntityWorldMut`].
+
+```rust,no_run
+# use bevy_ecs::prelude::*;
+# use bevy_sequential_actions::*;
+#
+# struct EmptyAction;
+# impl Action for EmptyAction {
+#   fn is_finished(&self, _a: Entity, _w: &World) -> bool { true }
+#   fn on_start(&mut self, _a: Entity, _w: &mut World) -> bool { true }
+#   fn on_stop(&mut self, _a: Entity, _w: &mut World, _r: StopReason) {}
+# }
+#
+fn setup(mut commands: Commands) {
+#   let action_a = EmptyAction;
+#   let action_b = EmptyAction;
+#   let action_c = EmptyAction;
+#
+    commands
+        // Spawn entity with the bundle
+        .spawn(ActionsBundle::new())
+        // Add a single action
+        .add_action(
+            AddConfig {
+                start: true, // Start next action if nothing is currently running
+                order: AddOrder::Back, // Add the action to the back of the queue
+            },
+            action_a,
+        )
+        // Add multiple actions
+        .add_actions(
+            AddConfig::default(),
+            actions![
+                action_b,
+                action_c
+            ],
+        )
+        // Add an anonymous action with a closure
+        .add_action(
+            AddConfig::default(),
+            |_agent, world: &mut World| -> bool {
+                // on_start
+                true
+            },
+        );
 }
 ```
 
@@ -151,9 +170,9 @@ the logic for advancing the action queue might not work properly.
 
 In general, there are two rules when modifying actions for an `agent` inside the action trait:
 
-* When adding new actions, you should either set the [`start`](ModifyActions::start) property to `false`,
+* When adding new actions, you should either set the [`start`](AddConfig::start) property in [`AddConfig`] to `false`,
     or push to the [`ActionQueue`] component directly.
-* The [`execute`](ModifyActions::execute) and [`next`](ModifyActions::next) methods should not be used.
+* The [`execute_actions`](ModifyActionsExt::execute_actions) and [`next_action`](ModifyActionsExt::next_action) methods should not be used.
 */
 
 use std::collections::VecDeque;

--- a/src/traits.rs
+++ b/src/traits.rs
@@ -77,6 +77,7 @@ pub trait ActionsProxy<'a> {
     fn actions(&'a mut self, agent: Entity) -> Self::Modifier;
 }
 
+#[deprecated]
 /// Methods for modifying actions.
 pub trait ModifyActions {
     /// Sets the current [`config`](AddConfig) for actions to be added.

--- a/src/traits.rs
+++ b/src/traits.rs
@@ -128,3 +128,19 @@ pub trait ModifyActions {
     /// Current action is [`stopped`](Action::on_stop) as [`canceled`](StopReason::Canceled).
     fn clear(&mut self) -> &mut Self;
 }
+
+pub trait ModifyActionsExt {
+    fn add_action(&mut self, config: AddConfig, action: impl Action) -> &mut Self;
+}
+
+impl ModifyActionsExt for EntityCommands<'_> {
+    fn add_action(&mut self, config: AddConfig, action: impl Action) -> &mut Self {
+        let agent = self.id();
+
+        self.commands().add(move |world: &mut World| {
+            SequentialActionsPlugin::add_action(agent, config, action, world);
+        });
+
+        self
+    }
+}

--- a/src/traits.rs
+++ b/src/traits.rs
@@ -270,6 +270,7 @@ impl ModifyActionsExt for EntityWorldMut<'_> {
         let agent = self.id();
 
         self.world_scope(move |world| {
+            SequentialActionsPlugin::stop_current_action(agent, StopReason::Canceled, world);
             SequentialActionsPlugin::start_next_action(agent, world);
         });
 

--- a/src/traits.rs
+++ b/src/traits.rs
@@ -229,3 +229,89 @@ impl ModifyActionsExt for EntityCommands<'_> {
         self
     }
 }
+
+impl ModifyActionsExt for EntityWorldMut<'_> {
+    fn add_action(&mut self, config: AddConfig, action: impl Action) -> &mut Self {
+        let agent = self.id();
+
+        self.world_scope(move |world| {
+            SequentialActionsPlugin::add_action(agent, config, action, world);
+        });
+
+        self
+    }
+
+    fn add_actions<I>(&mut self, config: AddConfig, actions: I) -> &mut Self
+    where
+        I: IntoIterator<Item = BoxedAction> + Send + 'static,
+        I::IntoIter: DoubleEndedIterator,
+    {
+        let agent = self.id();
+
+        self.world_scope(move |world| {
+            SequentialActionsPlugin::add_actions(agent, config, actions, world);
+        });
+
+        self
+    }
+
+    fn execute_actions(&mut self) -> &mut Self {
+        let agent = self.id();
+
+        self.world_scope(move |world| {
+            SequentialActionsPlugin::execute_actions(agent, world);
+        });
+
+        self
+    }
+
+    fn next_action(&mut self) -> &mut Self {
+        let agent = self.id();
+
+        self.world_scope(move |world| {
+            SequentialActionsPlugin::start_next_action(agent, world);
+        });
+
+        self
+    }
+
+    fn cancel_current_action(&mut self) -> &mut Self {
+        let agent = self.id();
+
+        self.world_scope(move |world| {
+            SequentialActionsPlugin::stop_current_action(agent, StopReason::Canceled, world);
+        });
+
+        self
+    }
+
+    fn pause_current_action(&mut self) -> &mut Self {
+        let agent = self.id();
+
+        self.world_scope(move |world| {
+            SequentialActionsPlugin::stop_current_action(agent, StopReason::Paused, world);
+        });
+
+        self
+    }
+
+    fn skip_next_action(&mut self) -> &mut Self {
+        let agent = self.id();
+
+        self.world_scope(move |world| {
+            SequentialActionsPlugin::skip_next_action(agent, world);
+        });
+
+        self
+    }
+
+    fn clear_actions(&mut self) -> &mut Self {
+        let agent = self.id();
+
+        self.world_scope(move |world| {
+            SequentialActionsPlugin::clear_actions(agent, world);
+        });
+
+        self
+    }
+}

--- a/src/traits.rs
+++ b/src/traits.rs
@@ -70,14 +70,28 @@ impl std::fmt::Debug for BoxedAction {
 
 /// Methods for modifying actions.
 pub trait ModifyActionsExt {
-    /// Adds a single [`action`](Action) to the queue.
-    fn add_action(&mut self, config: AddConfig, action: impl Action) -> &mut Self;
+    /// Adds a single [`action`](Action) to the queue with a specified [`config`](AddConfig).
+    fn add_action_with_config(&mut self, config: AddConfig, action: impl Action) -> &mut Self;
 
-    /// Adds a collection of actions to the queue.
-    fn add_actions<I>(&mut self, config: AddConfig, actions: I) -> &mut Self
+    /// Adds a collection of actions to the queue with a specified [`config`](AddConfig).
+    fn add_actions_with_config<I>(&mut self, config: AddConfig, actions: I) -> &mut Self
     where
         I: IntoIterator<Item = BoxedAction> + Send + 'static,
         I::IntoIter: DoubleEndedIterator;
+
+    /// Adds a single [`action`](Action) to the queue with a default [`config`](AddConfig).
+    fn add_action(&mut self, action: impl Action) -> &mut Self {
+        Self::add_action_with_config(self, AddConfig::default(), action)
+    }
+
+    /// Adds a collection of actions to the queue with a default [`config`](AddConfig).
+    fn add_actions<I>(&mut self, actions: I) -> &mut Self
+    where
+        I: IntoIterator<Item = BoxedAction> + Send + 'static,
+        I::IntoIter: DoubleEndedIterator,
+    {
+        Self::add_actions_with_config(self, AddConfig::default(), actions)
+    }
 
     /// [`Starts`](Action::on_start) the next [`action`](Action) in the queue,
     /// but only if there is no current action.

--- a/src/traits.rs
+++ b/src/traits.rs
@@ -92,13 +92,13 @@ pub trait ModifyActionsExt {
     ///
     /// To resume the action queue,
     /// call either [`execute_actions`](`Self::execute_actions`) or [`next_action`](`Self::next_action`).
-    fn cancel_current_action(&mut self) -> &mut Self;
+    fn cancel_action(&mut self) -> &mut Self;
 
     /// [`Stops`](Action::on_stop) the current action as [`paused`](StopReason::Paused).
     ///
     /// To resume the action queue,
     /// call either [`execute_actions`](`Self::execute_actions`) or [`next_action`](`Self::next_action`).
-    fn pause_current_action(&mut self) -> &mut Self;
+    fn pause_action(&mut self) -> &mut Self;
 
     /// Skips the next [`action`](Action) in the queue.
     fn skip_next_action(&mut self) -> &mut Self;

--- a/src/traits.rs
+++ b/src/traits.rs
@@ -91,13 +91,13 @@ pub trait ModifyActionsExt {
     /// [`Stops`](Action::on_stop) the current action as [`canceled`](StopReason::Canceled).
     ///
     /// To resume the action queue,
-    /// call either [`execute_actions`](Self::execute_actions) or [`next_actions`](Self::next_actions).
+    /// call either [`execute_actions`](`Self::execute_actions`) or [`next_action`](`Self::next_action`).
     fn cancel_current_action(&mut self) -> &mut Self;
 
     /// [`Stops`](Action::on_stop) the current action as [`paused`](StopReason::Paused).
     ///
     /// To resume the action queue,
-    /// call either [`execute_actions`](Self::execute_actions) or [`next_actions`](Self::next_actions).
+    /// call either [`execute_actions`](`Self::execute_actions`) or [`next_action`](`Self::next_action`).
     fn pause_current_action(&mut self) -> &mut Self;
 
     /// Skips the next [`action`](Action) in the queue.
@@ -109,7 +109,10 @@ pub trait ModifyActionsExt {
     fn clear_actions(&mut self) -> &mut Self;
 }
 
-#[deprecated]
+#[deprecated(
+    since = "0.12.0",
+    note = "Replaced by ModifyActionsExt trait implemented for EntityCommands and EntityWorldMut."
+)]
 /// Proxy method for modifying actions.
 pub trait ActionsProxy<'a> {
     /// The type returned for modifying actions.
@@ -119,7 +122,10 @@ pub trait ActionsProxy<'a> {
     fn actions(&'a mut self, agent: Entity) -> Self::Modifier;
 }
 
-#[deprecated]
+#[deprecated(
+    since = "0.12.0",
+    note = "Replaced by ModifyActionsExt trait implemented for EntityCommands and EntityWorldMut."
+)]
 /// Methods for modifying actions.
 pub trait ModifyActions {
     /// Sets the current [`config`](AddConfig) for actions to be added.

--- a/src/traits.rs
+++ b/src/traits.rs
@@ -68,6 +68,7 @@ impl std::fmt::Debug for BoxedAction {
     }
 }
 
+#[deprecated]
 /// Proxy method for modifying actions.
 pub trait ActionsProxy<'a> {
     /// The type returned for modifying actions.

--- a/src/world.rs
+++ b/src/world.rs
@@ -1,7 +1,7 @@
 use crate::*;
 
 impl ModifyActionsExt for EntityWorldMut<'_> {
-    fn add_action(&mut self, config: AddConfig, action: impl Action) -> &mut Self {
+    fn add_action_with_config(&mut self, config: AddConfig, action: impl Action) -> &mut Self {
         let agent = self.id();
 
         self.world_scope(move |world| {
@@ -11,7 +11,7 @@ impl ModifyActionsExt for EntityWorldMut<'_> {
         self
     }
 
-    fn add_actions<I>(&mut self, config: AddConfig, actions: I) -> &mut Self
+    fn add_actions_with_config<I>(&mut self, config: AddConfig, actions: I) -> &mut Self
     where
         I: IntoIterator<Item = BoxedAction> + Send + 'static,
         I::IntoIter: DoubleEndedIterator,

--- a/src/world.rs
+++ b/src/world.rs
@@ -46,7 +46,7 @@ impl ModifyActionsExt for EntityWorldMut<'_> {
         self
     }
 
-    fn cancel_current_action(&mut self) -> &mut Self {
+    fn cancel_action(&mut self) -> &mut Self {
         let agent = self.id();
 
         self.world_scope(move |world| {
@@ -56,7 +56,7 @@ impl ModifyActionsExt for EntityWorldMut<'_> {
         self
     }
 
-    fn pause_current_action(&mut self) -> &mut Self {
+    fn pause_action(&mut self) -> &mut Self {
         let agent = self.id();
 
         self.world_scope(move |world| {

--- a/src/world.rs
+++ b/src/world.rs
@@ -99,7 +99,10 @@ impl<'a> ActionsProxy<'a> for World {
     }
 }
 
-#[deprecated]
+#[deprecated(
+    since = "0.12.0",
+    note = "Replaced by ModifyActionsExt trait implemented for EntityCommands and EntityWorldMut."
+)]
 /// Modify actions using [`World`].
 pub struct AgentActions<'w> {
     agent: Entity,

--- a/src/world.rs
+++ b/src/world.rs
@@ -1,5 +1,92 @@
 use crate::*;
 
+impl ModifyActionsExt for EntityWorldMut<'_> {
+    fn add_action(&mut self, config: AddConfig, action: impl Action) -> &mut Self {
+        let agent = self.id();
+
+        self.world_scope(move |world| {
+            SequentialActionsPlugin::add_action(agent, config, action, world);
+        });
+
+        self
+    }
+
+    fn add_actions<I>(&mut self, config: AddConfig, actions: I) -> &mut Self
+    where
+        I: IntoIterator<Item = BoxedAction> + Send + 'static,
+        I::IntoIter: DoubleEndedIterator,
+    {
+        let agent = self.id();
+
+        self.world_scope(move |world| {
+            SequentialActionsPlugin::add_actions(agent, config, actions, world);
+        });
+
+        self
+    }
+
+    fn execute_actions(&mut self) -> &mut Self {
+        let agent = self.id();
+
+        self.world_scope(move |world| {
+            SequentialActionsPlugin::execute_actions(agent, world);
+        });
+
+        self
+    }
+
+    fn next_action(&mut self) -> &mut Self {
+        let agent = self.id();
+
+        self.world_scope(move |world| {
+            SequentialActionsPlugin::stop_current_action(agent, StopReason::Canceled, world);
+            SequentialActionsPlugin::start_next_action(agent, world);
+        });
+
+        self
+    }
+
+    fn cancel_current_action(&mut self) -> &mut Self {
+        let agent = self.id();
+
+        self.world_scope(move |world| {
+            SequentialActionsPlugin::stop_current_action(agent, StopReason::Canceled, world);
+        });
+
+        self
+    }
+
+    fn pause_current_action(&mut self) -> &mut Self {
+        let agent = self.id();
+
+        self.world_scope(move |world| {
+            SequentialActionsPlugin::stop_current_action(agent, StopReason::Paused, world);
+        });
+
+        self
+    }
+
+    fn skip_next_action(&mut self) -> &mut Self {
+        let agent = self.id();
+
+        self.world_scope(move |world| {
+            SequentialActionsPlugin::skip_next_action(agent, world);
+        });
+
+        self
+    }
+
+    fn clear_actions(&mut self) -> &mut Self {
+        let agent = self.id();
+
+        self.world_scope(move |world| {
+            SequentialActionsPlugin::clear_actions(agent, world);
+        });
+
+        self
+    }
+}
+
 impl<'a> ActionsProxy<'a> for World {
     type Modifier = AgentActions<'a>;
 
@@ -12,6 +99,7 @@ impl<'a> ActionsProxy<'a> for World {
     }
 }
 
+#[deprecated]
 /// Modify actions using [`World`].
 pub struct AgentActions<'w> {
     agent: Entity,

--- a/tests/tests.rs
+++ b/tests/tests.rs
@@ -22,6 +22,10 @@ impl TestApp {
         self.world_mut().spawn(ActionsBundle::new()).id()
     }
 
+    fn entity(&self, entity: Entity) -> EntityRef<'_> {
+        self.world().entity(entity)
+    }
+
     fn entity_mut(&mut self, entity: Entity) -> EntityWorldMut<'_> {
         self.world_mut().entity_mut(entity)
     }
@@ -153,7 +157,7 @@ fn add() {
     let mut app = TestApp::new();
     let a = app.spawn_agent();
 
-    app.entity_mut(a).add_action(
+    app.entity_mut(a).add_action_with_config(
         AddConfig {
             start: false,
             order: AddOrder::Back,
@@ -164,7 +168,7 @@ fn add() {
     assert!(app.current_action(a).is_none());
     assert!(app.action_queue(a).len() == 1);
 
-    app.entity_mut(a).clear_actions().add_action(
+    app.entity_mut(a).clear_actions().add_action_with_config(
         AddConfig {
             start: true,
             order: AddOrder::Back,
@@ -175,7 +179,7 @@ fn add() {
     assert!(app.current_action(a).is_none());
     assert!(app.action_queue(a).len() == 0);
 
-    app.entity_mut(a).clear_actions().add_action(
+    app.entity_mut(a).clear_actions().add_action_with_config(
         AddConfig {
             start: true,
             order: AddOrder::Back,
@@ -192,7 +196,7 @@ fn add_many() {
     let mut app = TestApp::new();
     let a = app.spawn_agent();
 
-    app.entity_mut(a).add_actions(
+    app.entity_mut(a).add_actions_with_config(
         AddConfig {
             start: false,
             order: AddOrder::Back,
@@ -203,7 +207,7 @@ fn add_many() {
     assert!(app.current_action(a).is_none());
     assert!(app.action_queue(a).len() == 2);
 
-    app.entity_mut(a).clear_actions().add_actions(
+    app.entity_mut(a).clear_actions().add_actions_with_config(
         AddConfig {
             start: true,
             order: AddOrder::Back,
@@ -214,7 +218,7 @@ fn add_many() {
     assert!(app.current_action(a).is_none());
     assert!(app.action_queue(a).len() == 0);
 
-    app.entity_mut(a).add_actions(
+    app.entity_mut(a).add_actions_with_config(
         AddConfig {
             start: true,
             order: AddOrder::Back,
@@ -225,7 +229,7 @@ fn add_many() {
     assert!(app.current_action(a).is_some());
     assert!(app.action_queue(a).len() == 1);
 
-    app.entity_mut(a).add_actions(
+    app.entity_mut(a).add_actions_with_config(
         AddConfig {
             start: true,
             order: AddOrder::Back,
@@ -242,7 +246,7 @@ fn next() {
     let mut app = TestApp::new();
     let a = app.spawn_agent();
 
-    app.entity_mut(a).add_action(
+    app.entity_mut(a).add_action_with_config(
         AddConfig {
             start: true,
             order: AddOrder::Back,
@@ -255,13 +259,13 @@ fn next() {
         .query_filtered::<Entity, With<CountdownMarker>>()
         .single(app.world());
 
-    assert_eq!(app.world().entity(e).contains::<Started>(), true);
-    assert_eq!(app.world().entity(e).contains::<Canceled>(), false);
+    assert_eq!(app.entity(e).contains::<Started>(), true);
+    assert_eq!(app.entity(e).contains::<Canceled>(), false);
 
     app.entity_mut(a).next_action();
 
-    assert_eq!(app.world().entity(e).contains::<Started>(), true);
-    assert_eq!(app.world().entity(e).contains::<Canceled>(), true);
+    assert_eq!(app.entity(e).contains::<Started>(), true);
+    assert_eq!(app.entity(e).contains::<Canceled>(), true);
 }
 
 #[test]
@@ -269,7 +273,7 @@ fn finish() {
     let mut app = TestApp::new();
     let a = app.spawn_agent();
 
-    app.entity_mut(a).add_action(
+    app.entity_mut(a).add_action_with_config(
         AddConfig {
             start: true,
             order: AddOrder::Back,
@@ -286,13 +290,13 @@ fn finish() {
         .query_filtered::<Entity, With<CountdownMarker>>()
         .single(app.world());
 
-    assert_eq!(app.world().entity(e).contains::<Finished>(), true);
-    assert_eq!(app.world().entity(e).contains::<Canceled>(), false);
-    assert_eq!(app.world().entity(e).contains::<Paused>(), false);
-    assert_eq!(app.world().entity(e).contains::<Dropped>(), true);
-    assert_eq!(app.world().entity(e).contains::<Done>(), true);
-    assert_eq!(app.world().entity(e).contains::<Skipped>(), false);
-    assert_eq!(app.world().entity(e).contains::<Cleared>(), false);
+    assert_eq!(app.entity(e).contains::<Finished>(), true);
+    assert_eq!(app.entity(e).contains::<Canceled>(), false);
+    assert_eq!(app.entity(e).contains::<Paused>(), false);
+    assert_eq!(app.entity(e).contains::<Dropped>(), true);
+    assert_eq!(app.entity(e).contains::<Done>(), true);
+    assert_eq!(app.entity(e).contains::<Skipped>(), false);
+    assert_eq!(app.entity(e).contains::<Cleared>(), false);
 }
 
 #[test]
@@ -301,7 +305,7 @@ fn cancel() {
     let a = app.spawn_agent();
 
     app.entity_mut(a)
-        .add_action(
+        .add_action_with_config(
             AddConfig {
                 start: true,
                 order: AddOrder::Back,
@@ -318,13 +322,13 @@ fn cancel() {
         .query_filtered::<Entity, With<CountdownMarker>>()
         .single(app.world());
 
-    assert_eq!(app.world().entity(e).contains::<Finished>(), false);
-    assert_eq!(app.world().entity(e).contains::<Canceled>(), true);
-    assert_eq!(app.world().entity(e).contains::<Paused>(), false);
-    assert_eq!(app.world().entity(e).contains::<Dropped>(), true);
-    assert_eq!(app.world().entity(e).contains::<Done>(), true);
-    assert_eq!(app.world().entity(e).contains::<Skipped>(), false);
-    assert_eq!(app.world().entity(e).contains::<Cleared>(), false);
+    assert_eq!(app.entity(e).contains::<Finished>(), false);
+    assert_eq!(app.entity(e).contains::<Canceled>(), true);
+    assert_eq!(app.entity(e).contains::<Paused>(), false);
+    assert_eq!(app.entity(e).contains::<Dropped>(), true);
+    assert_eq!(app.entity(e).contains::<Done>(), true);
+    assert_eq!(app.entity(e).contains::<Skipped>(), false);
+    assert_eq!(app.entity(e).contains::<Cleared>(), false);
 }
 
 #[test]
@@ -333,7 +337,7 @@ fn pause() {
     let a = app.spawn_agent();
 
     app.entity_mut(a)
-        .add_action(
+        .add_action_with_config(
             AddConfig {
                 start: true,
                 order: AddOrder::Back,
@@ -350,13 +354,13 @@ fn pause() {
         .query_filtered::<Entity, With<CountdownMarker>>()
         .single(app.world());
 
-    assert_eq!(app.world().entity(e).contains::<Finished>(), false);
-    assert_eq!(app.world().entity(e).contains::<Canceled>(), false);
-    assert_eq!(app.world().entity(e).contains::<Paused>(), true);
-    assert_eq!(app.world().entity(e).contains::<Dropped>(), false);
-    assert_eq!(app.world().entity(e).contains::<Done>(), false);
-    assert_eq!(app.world().entity(e).contains::<Skipped>(), false);
-    assert_eq!(app.world().entity(e).contains::<Cleared>(), false);
+    assert_eq!(app.entity(e).contains::<Finished>(), false);
+    assert_eq!(app.entity(e).contains::<Canceled>(), false);
+    assert_eq!(app.entity(e).contains::<Paused>(), true);
+    assert_eq!(app.entity(e).contains::<Dropped>(), false);
+    assert_eq!(app.entity(e).contains::<Done>(), false);
+    assert_eq!(app.entity(e).contains::<Skipped>(), false);
+    assert_eq!(app.entity(e).contains::<Cleared>(), false);
 }
 
 #[test]
@@ -365,7 +369,7 @@ fn skip() {
     let a = app.spawn_agent();
 
     app.entity_mut(a)
-        .add_action(
+        .add_action_with_config(
             AddConfig {
                 start: false,
                 order: AddOrder::Back,
@@ -381,14 +385,14 @@ fn skip() {
         .query_filtered::<Entity, With<CountdownMarker>>()
         .single(app.world());
 
-    assert_eq!(app.world().entity(e).contains::<Added>(), true);
-    assert_eq!(app.world().entity(e).contains::<Started>(), false);
-    assert_eq!(app.world().entity(e).contains::<Stopped>(), false);
-    assert_eq!(app.world().entity(e).contains::<Removed>(), true);
-    assert_eq!(app.world().entity(e).contains::<Dropped>(), true);
-    assert_eq!(app.world().entity(e).contains::<Done>(), false);
-    assert_eq!(app.world().entity(e).contains::<Skipped>(), true);
-    assert_eq!(app.world().entity(e).contains::<Cleared>(), false);
+    assert_eq!(app.entity(e).contains::<Added>(), true);
+    assert_eq!(app.entity(e).contains::<Started>(), false);
+    assert_eq!(app.entity(e).contains::<Stopped>(), false);
+    assert_eq!(app.entity(e).contains::<Removed>(), true);
+    assert_eq!(app.entity(e).contains::<Dropped>(), true);
+    assert_eq!(app.entity(e).contains::<Done>(), false);
+    assert_eq!(app.entity(e).contains::<Skipped>(), true);
+    assert_eq!(app.entity(e).contains::<Cleared>(), false);
 }
 
 #[test]
@@ -397,7 +401,7 @@ fn clear() {
     let a = app.spawn_agent();
 
     app.entity_mut(a)
-        .add_actions(
+        .add_actions_with_config(
             AddConfig {
                 start: true,
                 order: AddOrder::Back,
@@ -443,7 +447,7 @@ fn lifecycle() {
     let mut app = TestApp::new();
     let a = app.spawn_agent();
 
-    app.entity_mut(a).add_action(
+    app.entity_mut(a).add_action_with_config(
         AddConfig {
             start: false,
             order: AddOrder::Back,
@@ -456,35 +460,35 @@ fn lifecycle() {
         .query_filtered::<Entity, With<CountdownMarker>>()
         .single(app.world());
 
-    assert_eq!(app.world().entity(e).contains::<Added>(), true);
-    assert_eq!(app.world().entity(e).contains::<Started>(), false);
-    assert_eq!(app.world().entity(e).contains::<Stopped>(), false);
-    assert_eq!(app.world().entity(e).contains::<Removed>(), false);
-    assert_eq!(app.world().entity(e).contains::<Dropped>(), false);
+    assert_eq!(app.entity(e).contains::<Added>(), true);
+    assert_eq!(app.entity(e).contains::<Started>(), false);
+    assert_eq!(app.entity(e).contains::<Stopped>(), false);
+    assert_eq!(app.entity(e).contains::<Removed>(), false);
+    assert_eq!(app.entity(e).contains::<Dropped>(), false);
 
     app.entity_mut(a).execute_actions();
 
-    assert_eq!(app.world().entity(e).contains::<Added>(), true);
-    assert_eq!(app.world().entity(e).contains::<Started>(), true);
-    assert_eq!(app.world().entity(e).contains::<Stopped>(), false);
-    assert_eq!(app.world().entity(e).contains::<Removed>(), false);
-    assert_eq!(app.world().entity(e).contains::<Dropped>(), false);
+    assert_eq!(app.entity(e).contains::<Added>(), true);
+    assert_eq!(app.entity(e).contains::<Started>(), true);
+    assert_eq!(app.entity(e).contains::<Stopped>(), false);
+    assert_eq!(app.entity(e).contains::<Removed>(), false);
+    assert_eq!(app.entity(e).contains::<Dropped>(), false);
 
     app.entity_mut(a).pause_action();
 
-    assert_eq!(app.world().entity(e).contains::<Added>(), true);
-    assert_eq!(app.world().entity(e).contains::<Started>(), true);
-    assert_eq!(app.world().entity(e).contains::<Stopped>(), true);
-    assert_eq!(app.world().entity(e).contains::<Removed>(), false);
-    assert_eq!(app.world().entity(e).contains::<Dropped>(), false);
+    assert_eq!(app.entity(e).contains::<Added>(), true);
+    assert_eq!(app.entity(e).contains::<Started>(), true);
+    assert_eq!(app.entity(e).contains::<Stopped>(), true);
+    assert_eq!(app.entity(e).contains::<Removed>(), false);
+    assert_eq!(app.entity(e).contains::<Dropped>(), false);
 
     app.entity_mut(a).clear_actions();
 
-    assert_eq!(app.world().entity(e).contains::<Added>(), true);
-    assert_eq!(app.world().entity(e).contains::<Started>(), true);
-    assert_eq!(app.world().entity(e).contains::<Stopped>(), true);
-    assert_eq!(app.world().entity(e).contains::<Removed>(), true);
-    assert_eq!(app.world().entity(e).contains::<Dropped>(), true);
+    assert_eq!(app.entity(e).contains::<Added>(), true);
+    assert_eq!(app.entity(e).contains::<Started>(), true);
+    assert_eq!(app.entity(e).contains::<Stopped>(), true);
+    assert_eq!(app.entity(e).contains::<Removed>(), true);
+    assert_eq!(app.entity(e).contains::<Dropped>(), true);
 }
 
 #[test]
@@ -519,7 +523,7 @@ fn order() {
     let a = app.spawn_agent();
 
     // Back
-    app.entity_mut(a).add_actions(
+    app.entity_mut(a).add_actions_with_config(
         AddConfig {
             start: true,
             order: AddOrder::Back,
@@ -531,33 +535,33 @@ fn order() {
         ],
     );
 
-    assert_eq!(app.world().entity(a).contains::<A>(), true);
-    assert_eq!(app.world().entity(a).contains::<B>(), false);
-    assert_eq!(app.world().entity(a).contains::<C>(), false);
+    assert_eq!(app.entity(a).contains::<A>(), true);
+    assert_eq!(app.entity(a).contains::<B>(), false);
+    assert_eq!(app.entity(a).contains::<C>(), false);
 
     app.update();
 
-    assert_eq!(app.world().entity(a).contains::<A>(), false);
-    assert_eq!(app.world().entity(a).contains::<B>(), true);
-    assert_eq!(app.world().entity(a).contains::<C>(), false);
+    assert_eq!(app.entity(a).contains::<A>(), false);
+    assert_eq!(app.entity(a).contains::<B>(), true);
+    assert_eq!(app.entity(a).contains::<C>(), false);
 
     app.update();
 
-    assert_eq!(app.world().entity(a).contains::<A>(), false);
-    assert_eq!(app.world().entity(a).contains::<B>(), false);
-    assert_eq!(app.world().entity(a).contains::<C>(), true);
+    assert_eq!(app.entity(a).contains::<A>(), false);
+    assert_eq!(app.entity(a).contains::<B>(), false);
+    assert_eq!(app.entity(a).contains::<C>(), true);
 
     // Front
     app.entity_mut(a)
         .clear_actions()
-        .add_action(
+        .add_action_with_config(
             AddConfig {
                 start: false,
                 order: AddOrder::Back,
             },
             TestCountdownAction::new(0),
         )
-        .add_actions(
+        .add_actions_with_config(
             AddConfig {
                 start: false,
                 order: AddOrder::Front,
@@ -570,21 +574,21 @@ fn order() {
         )
         .execute_actions();
 
-    assert_eq!(app.world().entity(a).contains::<A>(), true);
-    assert_eq!(app.world().entity(a).contains::<B>(), false);
-    assert_eq!(app.world().entity(a).contains::<C>(), false);
+    assert_eq!(app.entity(a).contains::<A>(), true);
+    assert_eq!(app.entity(a).contains::<B>(), false);
+    assert_eq!(app.entity(a).contains::<C>(), false);
 
     app.update();
 
-    assert_eq!(app.world().entity(a).contains::<A>(), false);
-    assert_eq!(app.world().entity(a).contains::<B>(), true);
-    assert_eq!(app.world().entity(a).contains::<C>(), false);
+    assert_eq!(app.entity(a).contains::<A>(), false);
+    assert_eq!(app.entity(a).contains::<B>(), true);
+    assert_eq!(app.entity(a).contains::<C>(), false);
 
     app.update();
 
-    assert_eq!(app.world().entity(a).contains::<A>(), false);
-    assert_eq!(app.world().entity(a).contains::<B>(), false);
-    assert_eq!(app.world().entity(a).contains::<C>(), true);
+    assert_eq!(app.entity(a).contains::<A>(), false);
+    assert_eq!(app.entity(a).contains::<B>(), false);
+    assert_eq!(app.entity(a).contains::<C>(), true);
 }
 
 #[test]
@@ -596,7 +600,7 @@ fn pause_resume() {
         app.world_mut().query::<&Countdown>().single(app.world()).0
     }
 
-    app.entity_mut(a).add_action(
+    app.entity_mut(a).add_action_with_config(
         AddConfig {
             start: true,
             order: AddOrder::Back,
@@ -610,7 +614,7 @@ fn pause_resume() {
 
     assert_eq!(countdown_value(&mut app), 9);
 
-    app.entity_mut(a).pause_action().add_action(
+    app.entity_mut(a).pause_action().add_action_with_config(
         AddConfig {
             start: true,
             order: AddOrder::Front,
@@ -644,7 +648,7 @@ fn despawn() {
     let mut app = TestApp::new();
     let a = app.spawn_agent();
 
-    app.entity_mut(a).add_actions(
+    app.entity_mut(a).add_actions_with_config(
         AddConfig {
             start: true,
             order: AddOrder::Back,

--- a/tests/tests.rs
+++ b/tests/tests.rs
@@ -308,7 +308,7 @@ fn cancel() {
             },
             TestCountdownAction::new(1),
         )
-        .cancel_current_action();
+        .cancel_action();
 
     assert!(app.current_action(a).is_none());
     assert!(app.action_queue(a).is_empty());
@@ -340,7 +340,7 @@ fn pause() {
             },
             TestCountdownAction::new(1),
         )
-        .pause_current_action();
+        .pause_action();
 
     assert!(app.current_action(a).is_none());
     assert!(app.action_queue(a).len() == 1);
@@ -470,7 +470,7 @@ fn lifecycle() {
     assert_eq!(app.world().entity(e).contains::<Removed>(), false);
     assert_eq!(app.world().entity(e).contains::<Dropped>(), false);
 
-    app.entity_mut(a).pause_current_action();
+    app.entity_mut(a).pause_action();
 
     assert_eq!(app.world().entity(e).contains::<Added>(), true);
     assert_eq!(app.world().entity(e).contains::<Started>(), true);
@@ -610,7 +610,7 @@ fn pause_resume() {
 
     assert_eq!(countdown_value(&mut app), 9);
 
-    app.entity_mut(a).pause_current_action().add_action(
+    app.entity_mut(a).pause_action().add_action(
         AddConfig {
             start: true,
             order: AddOrder::Front,


### PR DESCRIPTION
This PR deprecates the `ModifyActions` trait in favor of the new `ModifyActionsExt` trait that is implemented for `EntityCommands` and `EntityWorldMut`. You can now chain entity spawning and adding actions instead of always having to store the entity ID before adding actions.

```rust
// before
let agent = commands.spawn(ActionsBundle::new()).id();
commands.actions(agent).add(action);

// after
commands.spawn(ActionsBundle::new()).add_action(action);
```