### PR TITLE
Add skip amount in `ModifyActions::skip`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 ## Version 0.12.0-dev
 
+- [Add how many actions to skip in `ModifyActions::skip`][105]
 - [Add multiple actions with a tuple][104]
     - Removes `add_many` as `add` can now be used instead
 - [Add cleanup of actions for despawned agents][101]
@@ -10,6 +11,7 @@
     - Replaces all unwraps with logging
     - Adds `on_remove_hook` and `on_remove_trigger` for both `CurrentAction` and `ActionQueue`
 
+[105]: https://github.com/hikikones/bevy-sequential-actions/pull/105
 [104]: https://github.com/hikikones/bevy-sequential-actions/pull/104
 [101]: https://github.com/hikikones/bevy-sequential-actions/pull/101
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,7 @@
 
 ## Version 0.12.0-dev
 
-- [Add how many actions to skip in `ModifyActions::skip`][105]
+- [Add skip amount in `ModifyActions::skip`][105]
 - [Add multiple actions with a tuple][104]
     - Removes `add_many` as `add` can now be used instead
 - [Add cleanup of actions for despawned agents][101]

--- a/src/commands.rs
+++ b/src/commands.rs
@@ -103,11 +103,11 @@ impl ModifyActions for AgentCommands<'_, '_, '_> {
         self
     }
 
-    fn skip(&mut self) -> &mut Self {
+    fn skip(&mut self, n: usize) -> &mut Self {
         let agent = self.agent;
 
         self.commands.add(move |world: &mut World| {
-            SequentialActionsPlugin::skip_next_action(agent, world);
+            SequentialActionsPlugin::skip_actions(agent, n, world);
         });
 
         self

--- a/src/plugin.rs
+++ b/src/plugin.rs
@@ -377,25 +377,35 @@ impl SequentialActionsPlugin {
         }
     }
 
-    /// Skips the next [`action`](Action) in the queue for `agent`.
-    pub fn skip_next_action(agent: Entity, world: &mut World) {
-        let Some(mut agent_ref) = world.get_entity_mut(agent) else {
-            warn!("Cannot skip next action for non-existent agent {agent}.");
-            return;
-        };
+    /// Skips the next `n` actions in the queue for `agent`.
+    pub fn skip_actions(agent: Entity, mut n: usize, world: &mut World) {
+        loop {
+            let Some(mut agent_ref) = world.get_entity_mut(agent) else {
+                warn!("Cannot skip next action for non-existent agent {agent}.");
+                return;
+            };
 
-        let Some(mut action_queue) = agent_ref.get_mut::<ActionQueue>() else {
-            warn!(
-                "Cannot skip next action for agent {agent} due to missing component {}.",
-                std::any::type_name::<ActionQueue>()
-            );
-            return;
-        };
+            let Some(mut action_queue) = agent_ref.get_mut::<ActionQueue>() else {
+                warn!(
+                    "Cannot skip next action for agent {agent} due to missing component {}.",
+                    std::any::type_name::<ActionQueue>()
+                );
+                return;
+            };
 
-        if let Some(mut action) = action_queue.pop_front() {
+            if n == 0 {
+                break;
+            }
+
+            let Some(mut action) = action_queue.pop_front() else {
+                break;
+            };
+
             debug!("Skipping action {action:?} for agent {agent}.");
             action.on_remove(agent.into(), world);
             action.on_drop(agent.into(), world, DropReason::Skipped);
+
+            n -= 1;
         }
     }
 

--- a/src/plugin.rs
+++ b/src/plugin.rs
@@ -380,9 +380,13 @@ impl SequentialActionsPlugin {
     /// Skips the next `n` actions in the queue for `agent`.
     pub fn skip_actions(agent: Entity, mut n: usize, world: &mut World) {
         loop {
+            if n == 0 {
+                break;
+            }
+
             let Some(mut agent_ref) = world.get_entity_mut(agent) else {
                 warn!("Cannot skip next action for non-existent agent {agent}.");
-                return;
+                break;
             };
 
             let Some(mut action_queue) = agent_ref.get_mut::<ActionQueue>() else {
@@ -390,12 +394,8 @@ impl SequentialActionsPlugin {
                     "Cannot skip next action for agent {agent} due to missing component {}.",
                     std::any::type_name::<ActionQueue>()
                 );
-                return;
-            };
-
-            if n == 0 {
                 break;
-            }
+            };
 
             let Some(mut action) = action_queue.pop_front() else {
                 break;

--- a/src/traits.rs
+++ b/src/traits.rs
@@ -168,8 +168,8 @@ pub trait ModifyActions {
     /// To resume the action queue, call either [`execute`](Self::execute) or [`next`](Self::next).
     fn pause(&mut self) -> &mut Self;
 
-    /// Skips the next [`action`](Action) in the queue.
-    fn skip(&mut self) -> &mut Self;
+    /// Skips the next `n` actions in the queue.
+    fn skip(&mut self, n: usize) -> &mut Self;
 
     /// Clears the action queue.
     ///

--- a/src/world.rs
+++ b/src/world.rs
@@ -73,8 +73,8 @@ impl ModifyActions for AgentActions<'_> {
         self
     }
 
-    fn skip(&mut self) -> &mut Self {
-        SequentialActionsPlugin::skip_next_action(self.agent, self.world);
+    fn skip(&mut self, n: usize) -> &mut Self {
+        SequentialActionsPlugin::skip_actions(self.agent, n, self.world);
         self
     }
 

--- a/tests/tests.rs
+++ b/tests/tests.rs
@@ -491,11 +491,11 @@ fn skip() {
 
     app.actions(a)
         .start(false)
-        .add_many(actions![
+        .add((
             CountdownAction::new(1),
             CountupAction::new(1),
-            CountupAction::new(1)
-        ])
+            CountupAction::new(1),
+        ))
         .skip(2);
 
     assert!(app.current_action(a).is_none());

--- a/tests/tests.rs
+++ b/tests/tests.rs
@@ -1,4 +1,4 @@
-use std::{marker::PhantomData, ops::Deref};
+use std::{marker::PhantomData, ops::Deref, usize};
 
 use bevy_app::prelude::*;
 use bevy_derive::{Deref, DerefMut};
@@ -462,20 +462,58 @@ fn skip() {
     app.actions(a)
         .start(false)
         .add(CountdownAction::new(1))
-        .skip();
+        .skip(0);
 
     assert!(app.current_action(a).is_none());
+    assert_eq!(app.action_queue(a).len(), 1);
+    assert_eq!(
+        app.hooks().deref().clone(),
+        vec![Hook::Add(Name::Countdown, a)]
+    );
+
+    app.actions(a).add(CountupAction::new(1)).skip(1);
+
+    assert!(app.current_action(a).is_some());
     assert_eq!(app.action_queue(a).len(), 0);
     assert_eq!(
         app.hooks().deref().clone(),
         vec![
             Hook::Add(Name::Countdown, a),
-            Hook::Remove(Name::Countdown, Some(a)),
-            Hook::Drop(Name::Countdown, Some(a), DropReason::Skipped)
+            Hook::Add(Name::Countup, a),
+            Hook::Start(Name::Countdown, a),
+            Hook::Remove(Name::Countup, Some(a)),
+            Hook::Drop(Name::Countup, Some(a), DropReason::Skipped)
         ]
     );
 
-    app.reset().actions(a).skip();
+    app.actions(a).clear();
+    app.hooks_mut().clear();
+
+    app.actions(a)
+        .start(false)
+        .add_many(actions![
+            CountdownAction::new(1),
+            CountupAction::new(1),
+            CountupAction::new(1)
+        ])
+        .skip(2);
+
+    assert!(app.current_action(a).is_none());
+    assert_eq!(app.action_queue(a).len(), 1);
+    assert_eq!(
+        app.hooks().deref().clone(),
+        vec![
+            Hook::Add(Name::Countdown, a),
+            Hook::Add(Name::Countup, a),
+            Hook::Add(Name::Countup, a),
+            Hook::Remove(Name::Countdown, Some(a)),
+            Hook::Drop(Name::Countdown, Some(a), DropReason::Skipped),
+            Hook::Remove(Name::Countup, Some(a)),
+            Hook::Drop(Name::Countup, Some(a), DropReason::Skipped),
+        ]
+    );
+
+    app.reset().actions(a).skip(usize::MAX);
 }
 
 #[test]


### PR DESCRIPTION
When skipping actions in the queue, you now need to specify how many:

```rust
commands.actions(agent).skip(1);
```
